### PR TITLE
Add support for fetching and dealing with job's information

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit-dep</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.8.6</version>

--- a/src/main/java/com/google/sps/FinalisedJob.java
+++ b/src/main/java/com/google/sps/FinalisedJob.java
@@ -1,0 +1,34 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps;
+
+import java.sql.Timestamp;
+import com.google.api.services.dataflow.model.Job;
+import com.google.api.services.dataflow.Dataflow;
+import java.io.IOException;
+import java.lang.IllegalArgumentException;
+
+
+// Class that deals with jobs that are stopped, finalised or
+// that failed and cant't have their status changed in the
+// future
+public final class FinalisedJob extends JobModel {
+    public FinalisedJob(String projectId, Job job, Dataflow dataflowService) throws IOException, IllegalArgumentException {
+        super(projectId, job, dataflowService);
+
+        state = job.getCurrentState();
+        stateTime = job.getCurrentStateTime();
+    }
+}

--- a/src/main/java/com/google/sps/FinalisedJob.java
+++ b/src/main/java/com/google/sps/FinalisedJob.java
@@ -21,9 +21,13 @@ import java.io.IOException;
 import java.lang.IllegalArgumentException;
 
 
-// Class that deals with jobs that are stopped, finalised or
-// that failed and cant't have their status changed in the
-// future
+// Class that deals with jobs that are in terminal state.
+// This class includes jobs that have the following states:
+// - JOB_STATE_DONE
+// - JOB_STATE_FAILED
+// - JOB_STATE_CANCELLED
+// - JOB_STATE_UPDATED
+// - JOB_STATE_DRAINED
 public final class FinalisedJob extends JobModel {
     public FinalisedJob(String projectId, Job job, Dataflow dataflowService) throws IOException, IllegalArgumentException {
         super(projectId, job, dataflowService);

--- a/src/main/java/com/google/sps/JobModel.java
+++ b/src/main/java/com/google/sps/JobModel.java
@@ -132,7 +132,7 @@ public abstract class JobModel {
 
     public static JobModel createJob(String projectId, Job job, Dataflow dataflowService)
         throws IOException, IllegalArgumentException {
-            String state = state = job.getCurrentState();
+            String state = job.getCurrentState();
             if (state.compareTo("JOB_STATE_UNKNOWN") == 0 
                    || state.compareTo("JOB_STATE_STOPPED") == 0
                    || state.compareTo("JOB_STATE_RUNNING") == 0

--- a/src/main/java/com/google/sps/JobModel.java
+++ b/src/main/java/com/google/sps/JobModel.java
@@ -129,4 +129,20 @@ public abstract class JobModel {
         }
       }    
     }
+
+    public static JobModel createJob(String projectId, Job job, Dataflow dataflowService)
+        throws IOException, IllegalArgumentException {
+            String state = state = job.getCurrentState();
+            if (state.compareTo("JOB_STATE_UNKNOWN") == 0 
+                   || state.compareTo("JOB_STATE_STOPPED") == 0
+                   || state.compareTo("JOB_STATE_RUNNING") == 0
+                   || state.compareTo("JOB_STATE_DRAINING") == 0
+                   || state.compareTo("JOB_STATE_PENDING") == 0
+                   || state.compareTo("JOB_STATE_CANCELLING") == 0
+                   || state.compareTo("JOB_STATE_QUEUED") == 0) {
+              return new RunningJob(projectId, job, dataflowService);
+            } else {
+                return new FinalisedJob(projectId, job, dataflowService);
+            }
+        }
 }

--- a/src/main/java/com/google/sps/JobModel.java
+++ b/src/main/java/com/google/sps/JobModel.java
@@ -1,0 +1,125 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps;
+
+import java.util.Date;
+import java.sql.Timestamp;
+import java.util.List;
+import com.google.api.services.dataflow.Dataflow;
+import com.google.api.services.dataflow.model.Job;
+import com.google.api.services.dataflow.model.JobMetadata;
+import com.google.api.services.dataflow.model.SdkVersion;
+import com.google.api.services.dataflow.model.Environment;
+import com.google.api.services.dataflow.model.WorkerPool;
+import com.google.api.services.dataflow.model.JobMetrics;
+import com.google.api.services.dataflow.model.MetricUpdate;
+import java.io.IOException;
+import java.lang.IllegalArgumentException;
+import java.math.BigDecimal;
+
+
+
+// Class used to represent a Job in memory, extracting just the 
+// information required by the analysis
+public abstract class JobModel {
+    public static final int SSD = 1;
+    public static final int HDD = 2;
+    String projectId;
+    String name;
+    String id;
+    String type;
+    String sdk = null;
+    String sdkSupportStatus = null;
+    String region;
+    String workerLocation;
+    int currentWorkers;
+    String startTime;
+
+    // Following fields stores the number of seconds
+    Long totalVCPUTime; // divide by 3600
+    Long totalMemoryTime; // divide by (3600 * 1024)
+    Long totalDiskTime;
+    int diskType;
+    Double currentVcpuCount;
+    Long totalStreamingData; //  multiply by 1024
+    Boolean enableStreamingEngine = false;
+    String metricTime;
+
+    String state;
+    String stateTime;
+
+    public JobModel(String projectId, Job job, Dataflow dataflowService) throws IOException, IllegalArgumentException {
+      this.projectId = projectId;
+      name = job.getName();
+      id = job.getId();
+      type = job.getType();
+      
+      SdkVersion sdkVersion = job.getJobMetadata().getSdkVersion();
+      if (sdkVersion != null) {
+          sdk = sdkVersion.getVersionDisplayName();
+          sdkSupportStatus =  sdkVersion.getSdkSupportStatus();
+      }
+
+      region = job.getLocation();
+
+      Environment environment = job.getEnvironment();
+      if (environment != null) {
+          workerLocation = environment.getWorkerRegion();
+
+          currentWorkers = 0;
+          List<WorkerPool> workerPoolList = environment.getWorkerPools();
+          if (workerPoolList != null) {
+            for (WorkerPool workerPool : workerPoolList) {
+              currentWorkers += workerPool.getNumWorkers();
+            }
+          }
+      }
+
+      
+      startTime = job.getStartTime();
+
+      getMetrics(dataflowService);
+    }
+
+    private void getMetrics(Dataflow dataflowService) throws IOException, IllegalArgumentException {
+        Dataflow.Projects.Locations.Jobs.GetMetrics request2 = dataflowService.projects()
+        .locations()
+        .jobs()
+        .getMetrics(projectId, region, id);
+        JobMetrics jobMetric = request2.execute();
+
+        metricTime = jobMetric.getMetricTime();
+
+        for (MetricUpdate metric : jobMetric.getMetrics()) {
+            String metricName = metric.getName().getName();
+            if (metricName.compareTo("TotalVcpuTime") == 0) {
+                totalVCPUTime = ((BigDecimal) metric.getScalar()).longValue();
+            } else if (metricName.compareTo("TotalMemoryUsage") == 0) {
+                totalMemoryTime = ((BigDecimal) metric.getScalar()).longValue();
+            } else if (metricName.compareTo("Service-pd_gb_seconds") == 0) {
+                totalDiskTime = ((BigDecimal) metric.getScalar()).longValue();
+                diskType = HDD;
+            } else if (metricName.compareTo("Service-pd_ssd_gb_seconds") == 0) {
+                totalDiskTime = ((BigDecimal) metric.getScalar()).longValue();
+                diskType = SSD;
+            } else if (metricName.compareTo("CurrentVcpuCount") == 0) {
+                currentVcpuCount = ((BigDecimal) metric.getScalar()).doubleValue();
+            } else if (metricName.compareTo("TotalStreamingDataProcessed") == 0) {
+                totalStreamingData = ((BigDecimal) metric.getScalar()).longValue();
+                enableStreamingEngine = true;
+            }
+        }
+    }
+}

--- a/src/main/java/com/google/sps/ProjectCenter.java
+++ b/src/main/java/com/google/sps/ProjectCenter.java
@@ -105,7 +105,7 @@ public final class ProjectCenter {
         // If the request was successful
         if (request.getLastStatusCode() >= 200 && request.getLastStatusCode() <  300) {
           if (job != null) {
-            return new RunningJob(projectId, job, dataflowService);
+            return JobModel.createJob(projectId, job, dataflowService);
           }
         }  
       }

--- a/src/main/java/com/google/sps/ProjectCenter.java
+++ b/src/main/java/com/google/sps/ProjectCenter.java
@@ -99,9 +99,11 @@ public final class ProjectCenter {
         try {
             job = request.execute();
         } catch (GoogleJsonResponseException e) {
+            // If we receive an error Message, we try further other regions
             continue;
         }
 
+        // If the request was successdful
         if (request.getLastStatusCode() >= 200 && request.getLastStatusCode() <  300) {
           if (job != null) {
             return new RunningJob(projectId, job, dataflowService);
@@ -129,7 +131,7 @@ public final class ProjectCenter {
       if (job != null) {
         return new RunningJob(projectId, job, dataflowService);
       }
-      
+
       return null;
     }
 }

--- a/src/main/java/com/google/sps/ProjectCenter.java
+++ b/src/main/java/com/google/sps/ProjectCenter.java
@@ -14,7 +14,6 @@
 
 package com.google.sps;
 
-
 import java.util.*;
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
@@ -103,7 +102,7 @@ public final class ProjectCenter {
             continue;
         }
 
-        // If the request was successdful
+        // If the request was successful
         if (request.getLastStatusCode() >= 200 && request.getLastStatusCode() <  300) {
           if (job != null) {
             return new RunningJob(projectId, job, dataflowService);

--- a/src/main/java/com/google/sps/RunningJob.java
+++ b/src/main/java/com/google/sps/RunningJob.java
@@ -1,0 +1,34 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps;
+
+import java.sql.Timestamp;
+import com.google.api.services.dataflow.model.Job;
+import com.google.api.services.dataflow.Dataflow;
+import java.io.IOException;
+import java.lang.IllegalArgumentException;
+
+
+
+// Class that deals with jobs that are currently running
+// or are already started and can have their status modified
+public final class RunningJob extends JobModel {
+    public RunningJob(String projectId, Job job, Dataflow dataflowService) throws IOException, IllegalArgumentException {
+        super(projectId, job, dataflowService);
+
+        state = job.getCurrentState();
+        stateTime = job.getCurrentStateTime();
+    }
+}

--- a/src/main/java/com/google/sps/RunningJob.java
+++ b/src/main/java/com/google/sps/RunningJob.java
@@ -22,8 +22,15 @@ import java.lang.IllegalArgumentException;
 
 
 
-// Class that deals with jobs that are currently running
-// or are already started and can have their status modified
+// Class that deals with jobs that can have their status modified
+// This includes jobs with the following states:
+// - JOB_STATE_UNKNOWN
+// - JOB_STATE_STOPPED
+// - JOB_STATE_RUNNING
+// - JOB_STATE_DRAINING
+// - JOB_STATE_PENDING
+// - JOB_STATE_CANCELLING
+// - JOB_STATE_QUEUED
 public final class RunningJob extends JobModel {
     public RunningJob(String projectId, Job job, Dataflow dataflowService) throws IOException, IllegalArgumentException {
         super(projectId, job, dataflowService);

--- a/src/test/java/com/google/sps/JobModelTest.java
+++ b/src/test/java/com/google/sps/JobModelTest.java
@@ -15,6 +15,7 @@
 package com.google.sps;
 
 import java.sql.Timestamp;
+import org.junit.Assume;
 import java.util.Arrays;
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,27 +36,38 @@ public final class JobModelTest {
     {
         return Arrays.asList(new Object[][] { 
             { "2020-08-06_06_01_04-4314082517434006770", "bt-dataflow-sql-demo", "dfsql-with-tumble", "JOB_TYPE_STREAMING",
-              "JOB_STATE_CANCELLED", "STALE", "2.23.0-SNAPSHOT", "europe-west2", 0 , "2020-08-06T13:01:05.239867Z"}, 
+              "JOB_STATE_CANCELLED", "STALE", "2.23.0-SNAPSHOT", "europe-west2", 0 , "2020-08-06T13:01:05.239867Z",
+                5.55, 20.813, 83.251, 0.0, 2, true, 15.53 }, 
             { "2020-08-06_05_48_10-15244611514655055844", "bt-dataflow-sql-demo", "dfsql-bt-easy-to-identify", "JOB_TYPE_STREAMING",
-              "JOB_STATE_CANCELLED", "STALE", "2.23.0-SNAPSHOT", "europe-west2", 0, "2020-08-06T12:48:11.885373Z" }, 
+              "JOB_STATE_CANCELLED", "STALE", "2.23.0-SNAPSHOT", "europe-west2", 0, "2020-08-06T12:48:11.885373Z",
+                5.98, 22.424, 89.696, 0.0, 2, true, 14.97 }, 
             { "2020-08-06_05_28_24-6040859398619218325", "bt-dataflow-sql-demo", "beamsqldemopipeline-ihr-0806122805-aa08f704", "JOB_TYPE_STREAMING",
-              "JOB_STATE_CANCELLED", "SUPPORTED", "2.23.0", "europe-west1", 0 , "2020-08-06T12:28:26.499518Z"}, 
+              "JOB_STATE_CANCELLED", "SUPPORTED", "2.23.0", "europe-west1", 0 , "2020-08-06T12:28:26.499518Z",
+                6.688, 25.082, 100.327, 0.0, 2, true, 30638.08 }, 
             { "2020-08-06_03_53_30-15110274477063034935", "bt-dataflow-sql-demo", "dfsql-65f4a130-173c3645af2", "JOB_TYPE_STREAMING",
-              "JOB_STATE_CANCELLED", "STALE", "2.23.0-SNAPSHOT", "us-central1", 0, "2020-08-06T10:53:31.543230Z" }, 
+              "JOB_STATE_CANCELLED", "STALE", "2.23.0-SNAPSHOT", "us-central1", 0, "2020-08-06T10:53:31.543230Z",
+                3.779, 14.17, 56.68, 0.0, 2, true, 9.06 }, 
             { "2020-08-06_03_50_01-9654167820707455539", "bt-dataflow-sql-demo", "dfsql-43d5b99-173c357c23e", "JOB_TYPE_STREAMING",
-              "JOB_STATE_CANCELLED", "STALE", "2.23.0-SNAPSHOT", "us-central1", 0, "2020-08-06T10:50:02.089393Z" },
+              "JOB_STATE_CANCELLED", "STALE", "2.23.0-SNAPSHOT", "us-central1", 0, "2020-08-06T10:50:02.089393Z",
+                3.876, 14.537, 58.146, 0.0, 2, true, 8.47 }, 
             { "2020-08-06_00_47_39-7199932943153518565", "bt-dataflow-sql-demo", "beamsqldemopipeline-ihr-0806074705-d05f6ed7", "JOB_TYPE_STREAMING",
-              "JOB_STATE_CANCELLED", "SUPPORTED", "2.23.0", "europe-west1", 0, "2020-08-06T07:47:41.890279Z" },
+              "JOB_STATE_CANCELLED", "SUPPORTED", "2.23.0", "europe-west1", 0, "2020-08-06T07:47:41.890279Z",
+                26.666, 99.998, 399.992, 0.0, 6, true, 94699.52 }, 
             { "2020-08-05_02_07_44-11496906389150035870", "bt-dataflow-sql-demo", "dfsql-join-and-window", "JOB_TYPE_STREAMING", 
-              "JOB_STATE_CANCELLED", "STALE", "2.23.0-SNAPSHOT", "us-central1", 0, "2020-08-05T09:07:45.269405Z" },
+              "JOB_STATE_CANCELLED", "STALE", "2.23.0-SNAPSHOT", "us-central1", 0, "2020-08-05T09:07:45.269405Z",
+                0.656, 2.461, 9.844, 0.0, 2, true, 0.0 }, 
             { "2020-08-05_01_27_19-12034076432132404549", "bt-dataflow-sql-demo", "dfsql-query-example-topic-table", "JOB_TYPE_STREAMING", 
-              "JOB_STATE_CANCELLED", "STALE", "2.23.0-SNAPSHOT", "us-central1", 0, "2020-08-05T08:27:20.292802Z" },
+              "JOB_STATE_CANCELLED", "STALE", "2.23.0-SNAPSHOT", "us-central1", 0, "2020-08-05T08:27:20.292802Z",
+                1.197, 4.489, 17.958, 0.0, 2, true, 3.34 }, 
             { "2020-08-04_14_46_51-10622717568042133093", "bt-dataflow-sql-demo", "beamsqldemopipeline-ihr-0804214611-d6c2f941", "JOB_TYPE_STREAMING",
-              "JOB_STATE_CANCELLED", "SUPPORTED", "2.23.0", "europe-west1", 0, "2020-08-04T21:46:53.637572Z" },
+              "JOB_STATE_CANCELLED", "SUPPORTED", "2.23.0", "europe-west1", 0, "2020-08-04T21:46:53.637572Z",
+                547.03, 2051.36, 8205.456, 0.0, 6, true, 390584.32 }, 
             { "2020-08-04_14_33_26-5454611298510143581", "bt-dataflow-sql-demo", "beamsqldemopipeline-ihr-0804213246-8dbbe1e9", "JOB_TYPE_STREAMING", 
-              "JOB_STATE_CANCELLED", "SUPPORTED", "2.23.0", "europe-west1", 0, "2020-08-04T21:33:28.350686Z" },
+              "JOB_STATE_CANCELLED", "SUPPORTED", "2.23.0", "europe-west1", 0, "2020-08-04T21:33:28.350686Z",
+                0.326, 1.222, 4.889, 0.0, 2, true, 61.91  }, 
             { "2020-08-04_13_09_00-4586883393904972800", "bt-dataflow-sql-demo", "beamsqldemopipeline-ihr-0804200823-809e448a", "JOB_TYPE_STREAMING", 
-              "JOB_STATE_FAILED", "SUPPORTED", "2.23.0", "europe-west1", 0, "2020-08-04T20:09:02.212104Z" } }); // Failed
+              "JOB_STATE_FAILED", "SUPPORTED", "2.23.0", "europe-west1", 0, "2020-08-04T20:09:02.212104Z",
+                null, null, null, null, null, false, null } }); // Failed
     }
 
     private ProjectCenter projectCenter;
@@ -72,10 +84,20 @@ public final class JobModelTest {
     private final String region;
     private final int currentWorkers;
     private final String startTime;
+    private final Double totalVCPUTime; // in hours
+    private final Double totalMemoryTime; // in Gb hours
+    private final Double totalDiskTimeHDD; // in GB hours
+    private final Double totalDiskTimeSSD; // in GB hours
+    private final Integer currentVcpuCount;
+    private final Double totalStreamingData; // in MB
+    private final Boolean enableStreamingEngine;
 
     public JobModelTest(final String jobId, final String projectId, final String name, final String type,
-                                        final String status, final String sdkStatus, final String sdk, 
-                                            final String region, final int currentWorkers, final String startTime)
+                            final String status, final String sdkStatus, final String sdk, 
+                                final String region, final int currentWorkers, final String startTime,
+                                    final Double totalVCPUTime, final Double totalMemoryTime, final Double totalDiskTimeHDD,
+                                        final Double totalDiskTimeSSD, final Integer currentVcpuCount,
+                                            final Boolean enableStreamingEngine, final Double totalStreamingData)
                                                 throws IOException, GeneralSecurityException {
       this.jobId = jobId;
       this.projectId = projectId;
@@ -87,6 +109,13 @@ public final class JobModelTest {
       this.region = region;
       this.currentWorkers = currentWorkers;
       this.startTime = startTime;
+      this.totalVCPUTime = totalVCPUTime;
+      this.totalMemoryTime = totalMemoryTime;
+      this.totalDiskTimeHDD = totalDiskTimeHDD;
+      this.totalDiskTimeSSD = totalDiskTimeSSD;
+      this.currentVcpuCount = currentVcpuCount;
+      this.enableStreamingEngine = enableStreamingEngine;
+      this.totalStreamingData = totalStreamingData;
 
       projectCenter = new ProjectCenter("bt-dataflow-sql-demo", "bt-dataflow-sql-demo.json");
       jobModel = projectCenter.fetch(jobId, region);
@@ -128,5 +157,86 @@ public final class JobModelTest {
         Assert.assertEquals(startTime, jobModel.startTime);
     }
 
+    @Test
+    public void TestTotalVCPUTimeInHours() {
+        Assume.assumeTrue(jobModel.state.compareTo("JOB_STATE_FAILED") != 0);
+        Double actualVCPUTimeinHours = (jobModel.totalVCPUTime / 3600);
+        Assert.assertEquals(totalVCPUTime, actualVCPUTimeinHours, 0.001);
+    }
 
+    public void TestTotalVCPUTimeInHoursFailedJob() {
+        Assume.assumeTrue(jobModel.state.compareTo("JOB_STATE_FAILED") == 0);
+        Assert.assertEquals(null, jobModel.totalVCPUTime);
+    }
+
+    @Test
+    public void TestTotalMemoryTimeInGBHours() {
+        Assume.assumeTrue(jobModel.state.compareTo("JOB_STATE_FAILED") != 0);
+        Double actualTotalMemoryTimeinGBHours = (jobModel.totalMemoryTime / (3600 * 1024));
+        Assert.assertEquals(totalMemoryTime, actualTotalMemoryTimeinGBHours, 0.005);
+    }
+
+    @Test
+    public void TestTotalMemoryTimeInGBHoursFailedJob() {
+        Assume.assumeTrue(jobModel.state.compareTo("JOB_STATE_FAILED") == 0);
+        Assert.assertEquals(null, jobModel.totalMemoryTime);
+    }
+
+    @Test
+    public void TestTotalDiskTimeHDD() {
+        Assume.assumeTrue(jobModel.state.compareTo("JOB_STATE_FAILED") != 0);
+        Double actualTotalDiskTimeHDD = jobModel.totalDiskTimeHDD / 3600;
+        Assert.assertEquals(totalDiskTimeHDD, actualTotalDiskTimeHDD, 0.001);
+    }
+
+    @Test
+    public void TestTotalDiskTimeHDDFailedJob() {
+        Assume.assumeTrue(jobModel.state.compareTo("JOB_STATE_FAILED") == 0);
+        Assert.assertEquals(null, jobModel.totalDiskTimeHDD);
+    }
+
+    @Test
+    public void TestTotalDiskTimeSSD() {
+        Assume.assumeTrue(jobModel.state.compareTo("JOB_STATE_FAILED") != 0);
+        Double actualTotalDiskTimeSSD = jobModel.totalDiskTimeSSD / 3600;
+        Assert.assertEquals(totalDiskTimeSSD, actualTotalDiskTimeSSD, 0.001);
+    }
+
+    @Test
+    public void TestTotalDiskTimeSSDFailedJob() {
+        Assume.assumeTrue(jobModel.state.compareTo("JOB_STATE_FAILED") == 0);
+        Assert.assertEquals(null, jobModel.totalDiskTimeSSD);
+    }
+
+    @Test
+    public void TestCurrentVcpuCount() {
+        Assume.assumeTrue(jobModel.state.compareTo("JOB_STATE_FAILED") != 0);
+        Assert.assertEquals(currentVcpuCount, jobModel.currentVcpuCount);
+    }
+
+    @Test
+    public void TestCurrentVcpuCountFailedJob() {
+        Assume.assumeTrue(jobModel.state.compareTo("JOB_STATE_FAILED") == 0);
+        Assert.assertEquals(null, jobModel.currentVcpuCount);
+    }
+
+    @Test
+    public void TestEnableStreamingEngine() {
+        Assert.assertEquals(enableStreamingEngine, jobModel.enableStreamingEngine);
+    }
+
+    @Test
+    public void TestTotalStreamingData() {
+        Assume.assumeTrue(jobModel.enableStreamingEngine);
+        Double actualTotalStreamingData = jobModel.totalStreamingData * 1024;
+        Assert.assertEquals(totalStreamingData, actualTotalStreamingData, 5);
+    }
+
+    @Test
+    public void TestTotalStreamingNotEnabled() {
+        Assume.assumeTrue(!jobModel.enableStreamingEngine);
+        Assert.assertEquals(null, jobModel.totalStreamingData);
+    }
+
+    
 }

--- a/src/test/java/com/google/sps/JobModelTest.java
+++ b/src/test/java/com/google/sps/JobModelTest.java
@@ -1,0 +1,132 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps;
+
+import java.sql.Timestamp;
+import java.util.Arrays;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.Ignore;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+@RunWith(Parameterized.class)
+public final class JobModelTest {
+
+    @Parameters(name = "JobId : {0}")
+    public static Iterable<Object []> data() 
+    {
+        return Arrays.asList(new Object[][] { 
+            { "2020-08-06_06_01_04-4314082517434006770", "bt-dataflow-sql-demo", "dfsql-with-tumble", "JOB_TYPE_STREAMING",
+              "JOB_STATE_CANCELLED", "STALE", "2.23.0-SNAPSHOT", "europe-west2", 0 , "2020-08-06T13:01:05.239867Z"}, 
+            { "2020-08-06_05_48_10-15244611514655055844", "bt-dataflow-sql-demo", "dfsql-bt-easy-to-identify", "JOB_TYPE_STREAMING",
+              "JOB_STATE_CANCELLED", "STALE", "2.23.0-SNAPSHOT", "europe-west2", 0, "2020-08-06T12:48:11.885373Z" }, 
+            { "2020-08-06_05_28_24-6040859398619218325", "bt-dataflow-sql-demo", "beamsqldemopipeline-ihr-0806122805-aa08f704", "JOB_TYPE_STREAMING",
+              "JOB_STATE_CANCELLED", "SUPPORTED", "2.23.0", "europe-west1", 0 , "2020-08-06T12:28:26.499518Z"}, 
+            { "2020-08-06_03_53_30-15110274477063034935", "bt-dataflow-sql-demo", "dfsql-65f4a130-173c3645af2", "JOB_TYPE_STREAMING",
+              "JOB_STATE_CANCELLED", "STALE", "2.23.0-SNAPSHOT", "us-central1", 0, "2020-08-06T10:53:31.543230Z" }, 
+            { "2020-08-06_03_50_01-9654167820707455539", "bt-dataflow-sql-demo", "dfsql-43d5b99-173c357c23e", "JOB_TYPE_STREAMING",
+              "JOB_STATE_CANCELLED", "STALE", "2.23.0-SNAPSHOT", "us-central1", 0, "2020-08-06T10:50:02.089393Z" },
+            { "2020-08-06_00_47_39-7199932943153518565", "bt-dataflow-sql-demo", "beamsqldemopipeline-ihr-0806074705-d05f6ed7", "JOB_TYPE_STREAMING",
+              "JOB_STATE_CANCELLED", "SUPPORTED", "2.23.0", "europe-west1", 0, "2020-08-06T07:47:41.890279Z" },
+            { "2020-08-05_02_07_44-11496906389150035870", "bt-dataflow-sql-demo", "dfsql-join-and-window", "JOB_TYPE_STREAMING", 
+              "JOB_STATE_CANCELLED", "STALE", "2.23.0-SNAPSHOT", "us-central1", 0, "2020-08-05T09:07:45.269405Z" },
+            { "2020-08-05_01_27_19-12034076432132404549", "bt-dataflow-sql-demo", "dfsql-query-example-topic-table", "JOB_TYPE_STREAMING", 
+              "JOB_STATE_CANCELLED", "STALE", "2.23.0-SNAPSHOT", "us-central1", 0, "2020-08-05T08:27:20.292802Z" },
+            { "2020-08-04_14_46_51-10622717568042133093", "bt-dataflow-sql-demo", "beamsqldemopipeline-ihr-0804214611-d6c2f941", "JOB_TYPE_STREAMING",
+              "JOB_STATE_CANCELLED", "SUPPORTED", "2.23.0", "europe-west1", 0, "2020-08-04T21:46:53.637572Z" },
+            { "2020-08-04_14_33_26-5454611298510143581", "bt-dataflow-sql-demo", "beamsqldemopipeline-ihr-0804213246-8dbbe1e9", "JOB_TYPE_STREAMING", 
+              "JOB_STATE_CANCELLED", "SUPPORTED", "2.23.0", "europe-west1", 0, "2020-08-04T21:33:28.350686Z" },
+            { "2020-08-04_13_09_00-4586883393904972800", "bt-dataflow-sql-demo", "beamsqldemopipeline-ihr-0804200823-809e448a", "JOB_TYPE_STREAMING", 
+              "JOB_STATE_FAILED", "SUPPORTED", "2.23.0", "europe-west1", 0, "2020-08-04T20:09:02.212104Z" } }); // Failed
+    }
+
+    private ProjectCenter projectCenter;
+
+    private JobModel jobModel;
+
+    private final String jobId;
+    private final String projectId;
+    private final String name;
+    private final String type;
+    private final String status;
+    private final String sdkStatus;
+    private final String sdk;
+    private final String region;
+    private final int currentWorkers;
+    private final String startTime;
+
+    public JobModelTest(final String jobId, final String projectId, final String name, final String type,
+                                        final String status, final String sdkStatus, final String sdk, 
+                                            final String region, final int currentWorkers, final String startTime)
+                                                throws IOException, GeneralSecurityException {
+      this.jobId = jobId;
+      this.projectId = projectId;
+      this.name = name;
+      this.type = type;
+      this.status = status;
+      this.sdkStatus = sdkStatus;
+      this.sdk = sdk;
+      this.region = region;
+      this.currentWorkers = currentWorkers;
+      this.startTime = startTime;
+
+      projectCenter = new ProjectCenter("bt-dataflow-sql-demo", "bt-dataflow-sql-demo.json");
+      jobModel = projectCenter.fetch(jobId, region);
+    }
+
+    @Test
+    public void TestProjectIdforJob() {
+        Assert.assertEquals(projectId, jobModel.projectId);
+    }
+
+    @Test
+    public void TestNameforJob() {
+        Assert.assertEquals(name, jobModel.name);
+    }
+
+    @Test
+    public void TestTypeforJob() {
+        Assert.assertEquals(type, jobModel.type);
+    }
+
+    @Test
+    public void TestSDKStatusforJob() {
+        Assert.assertEquals(sdkStatus, jobModel.sdkSupportStatus);
+    }
+
+    @Test
+    public void TestSDKforJob() {
+        Assert.assertEquals(sdk, jobModel.sdk);
+    }
+
+    // TODO: - add test with currentWorkers != 0;
+    @Test
+    public void TestCurrentWorkers() {
+        Assert.assertEquals(currentWorkers, jobModel.currentWorkers);
+    }
+
+    @Test
+    public void TestStartTime() {
+        Assert.assertEquals(startTime, jobModel.startTime);
+    }
+
+
+}

--- a/src/test/java/com/google/sps/ProjectCenterTest.java
+++ b/src/test/java/com/google/sps/ProjectCenterTest.java
@@ -71,7 +71,5 @@ public final class ProjectCenterTest {
         JobModel actualJob = projectCenter.fetch("2020-08-06_06_01_04-4314082517434006770", "asia-east1");
         JobModel expectedJob = null;
         Assert.assertEquals(actualJob, expectedJob);
-    }
-
-    
+    }   
 }

--- a/src/test/java/com/google/sps/ProjectCenterTest.java
+++ b/src/test/java/com/google/sps/ProjectCenterTest.java
@@ -27,14 +27,51 @@ public final class ProjectCenterTest {
     private ProjectCenter projectCenter;
 
     @Before
-    public void setUp() throws IOException {
+    public void setUp() throws IOException , GeneralSecurityException {
       projectCenter = new ProjectCenter("bt-dataflow-sql-demo", "bt-dataflow-sql-demo.json");
     }
 
     @Test
-    public void fetchJobsTest() throws IOException, GeneralSecurityException {
+    public void fetchJobsTest() throws IOException {
       int actualNumberJobs = projectCenter.fetchJobs().size();
       int expectedNumberJobs = 17;
       Assert.assertEquals(actualNumberJobs, expectedNumberJobs);
-  }
+    }
+
+    @Test
+    public void fetchTest() throws IOException {
+        String actualName = projectCenter.fetch("2020-08-06_06_01_04-4314082517434006770").name;
+        String expectedName = "dfsql-with-tumble";
+        Assert.assertEquals(actualName, expectedName);
+    }
+
+    @Test
+    public void fetchKnownLocationTest() throws IOException {
+        String actualName = projectCenter.fetch("2020-08-06_06_01_04-4314082517434006770", "europe-west2").name;
+        String expectedName = "dfsql-with-tumble";
+        Assert.assertEquals(actualName, expectedName);
+    }
+
+    @Test 
+    public void fetchJobNotFoundTest() throws IOException {
+        JobModel actualJob = projectCenter.fetch("dumb-id");
+        JobModel expectedJob = null;
+        Assert.assertEquals(actualJob, expectedJob);
+    }
+
+    @Test 
+    public void fetchJobNotFoundKnownLocationTest() throws IOException {
+        JobModel actualJob = projectCenter.fetch("dumb-id", "asia-east1");
+        JobModel expectedJob = null;
+        Assert.assertEquals(actualJob, expectedJob);
+    }
+
+     @Test 
+    public void fetchJobNotFoundWrongLocationTest() throws IOException {
+        JobModel actualJob = projectCenter.fetch("2020-08-06_06_01_04-4314082517434006770", "asia-east1");
+        JobModel expectedJob = null;
+        Assert.assertEquals(actualJob, expectedJob);
+    }
+
+    
 }


### PR DESCRIPTION
1. Add functionality to ProjectCenter to fetch a single job, based on the job's id or on both the job's id and location
2. Add Unit Test for checking the functionality of the ProjectCenter
2. Add abstract class that gets and models all the information required for a job
3. Add instantiable classes RunningJob and FinalisedJob to have separate methods for jobs that are currently running (and that can be updated) or jobs that are finalised ( canceled / finalised) and can no longer be modified.
5. Add Unit Test for Job Model class, checking for the Job Info and resource Metrics