### PR TITLE
Add support for aggregating the jobs based on the programming language used for the SDK

### DIFF
--- a/src/main/java/com/google/sps/AggregationCenter.java
+++ b/src/main/java/com/google/sps/AggregationCenter.java
@@ -57,27 +57,11 @@ public final class AggregationCenter {
       return agreggateByGroupIndex(jobs, 1);
   }
 
-  public Map<String, List<JobJSON>> aggregateByRegion(List<JobJSON> jobs) {
+  private Map<String, List<JobJSON>> aggregateBy(List<JobJSON> jobs, KeyGenerator keyGenerator) {
     Map<String, List<JobJSON>> groupedJobs = new HashMap<>();
 
     for (JobJSON job : jobs) {
-      if (groupedJobs.containsKey(job.region)) {
-        groupedJobs.get(job.region).add(job);
-      } else {
-        List<JobJSON> list = new ArrayList<JobJSON>();
-        list.add(job);
-        groupedJobs.put(job.region, list);
-      }
-    }
-
-    return groupedJobs;
-  }
-
-  public Map<String, List<JobJSON>> aggregateBySDK(List<JobJSON> jobs) {
-    Map<String, List<JobJSON>> groupedJobs = new HashMap<>();
-
-    for (JobJSON job : jobs) {
-      String key = job.sdk + " " + job.sdkSupportStatus;
+      String key = keyGenerator.computeKey(job);
       if (groupedJobs.containsKey(key)) {
         groupedJobs.get(key).add(job);
       } else {
@@ -89,4 +73,46 @@ public final class AggregationCenter {
 
     return groupedJobs;
   }
+
+  public Map<String, List<JobJSON>> aggregateByRegion(List<JobJSON> jobs) {
+    return aggregateBy(jobs, new KeyGenerator() {
+      public String computeKey(JobJSON job) {
+          return job.region;
+      }
+    }) ;
+  }
+
+  public Map<String, List<JobJSON>> aggregateBySDK(List<JobJSON> jobs) {
+    return aggregateBy(jobs, new KeyGenerator() {
+      public String computeKey(JobJSON job) {
+          return job.sdk + " " + job.sdkSupportStatus;
+      }
+    }) ;
+  }
+
+  public Map<String, List<JobJSON>> aggregateBySDKSupportStatus(List<JobJSON> jobs) {
+    return aggregateBy(jobs, new KeyGenerator() {
+      public String computeKey(JobJSON job) {
+          return job.sdkSupportStatus;
+      }
+    }) ;
+  }
+
+  public Map<String, List<JobJSON>> aggregateByProgrammingLanguage(List<JobJSON> jobs) {
+    return aggregateBy(jobs, new KeyGenerator() {
+      public String computeKey(JobJSON job) {
+        String key = job.sdkName;
+        if (key.contains("Java")) {
+          key = "Java";
+        } else if (key.contains("Python")) {
+          key = "Python";
+        }
+        return key;
+      }
+    }) ;
+  }
+}
+
+interface KeyGenerator {
+    public String computeKey(JobJSON job);
 }

--- a/src/main/java/com/google/sps/JobStoreCenter.java
+++ b/src/main/java/com/google/sps/JobStoreCenter.java
@@ -76,6 +76,7 @@ public final class JobStoreCenter {
     jobEntity.setProperty("metricTime", job.metricTime);
     jobEntity.setProperty("state", job.state);
     jobEntity.setProperty("stateTime", job.stateTime);
+    jobEntity.setProperty("sdkName", job.sdkName);
 
     PriceCenter priceCenter = new PriceCenter();
     jobEntity.setProperty("price", priceCenter.calculatePrice(job));
@@ -129,12 +130,13 @@ public final class JobStoreCenter {
         String state = (String) entity.getProperty("state");
         String stateTime = (String) entity.getProperty("stateTime");
         Double price = (Double) entity.getProperty("price");
+        String sdkName = (String) entity.getProperty("sdkName");
 
         JobJSON job = new JobJSON(projectId, name, id, type, sdk, sdkSupportStatus, region, 
                                      currentWorkers, startTime, totalVCPUTime, totalMemoryTime,
                                         totalDiskTimeHDD, totalDiskTimeSSD, currentVcpuCount,
                                             totalStreamingData, enableStreamingEngine, metricTime,
-                                                state, stateTime, price);
+                                                state, stateTime, price, sdkName);
         
         jobs.add(job);
       }

--- a/src/main/java/com/google/sps/data/JobJSON.java
+++ b/src/main/java/com/google/sps/data/JobJSON.java
@@ -23,6 +23,7 @@ public final class JobJSON {
   // sdkSupportStatus can be found at 
   // https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.jobs#sdksupportstatus
   public String sdkSupportStatus = null;
+  public String sdkName;
   public String region;
   public int currentWorkers;
   public String startTime;
@@ -46,7 +47,7 @@ public final class JobJSON {
                     String region, int currentWorkers, String startTime, Double totalVCPUTime, Double totalMemoryTime,
                         Double totalDiskTimeHDD, Double totalDiskTimeSSD, Integer currentVcpuCount,
                             Double totalStreamingData, Boolean enableStreamingEngine, String metricTime, 
-                                String state, String stateTime, Double price) {
+                                String state, String stateTime, Double price, String sdkName) {
     this.projectId = projectId;
     this.name = name;
     this.id = id;
@@ -68,5 +69,6 @@ public final class JobJSON {
     this.stateTime = stateTime;
 
     this.price = price;
+    this.sdkName = sdkName;
   }
 }

--- a/src/main/java/com/google/sps/data/JobModel.java
+++ b/src/main/java/com/google/sps/data/JobModel.java
@@ -20,6 +20,7 @@ import com.google.api.services.dataflow.model.MetricUpdate;
 import java.io.IOException;
 import java.lang.IllegalArgumentException;
 import java.math.BigDecimal;
+import java.util.Map;
 
 
 
@@ -39,6 +40,7 @@ public abstract class JobModel {
     // sdkSupportStatus can be found at 
     // https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.jobs#sdksupportstatus
     public String sdkSupportStatus = null;
+    public String sdkName;
     public String region;
     public int currentWorkers;
     public String startTime;
@@ -81,6 +83,9 @@ public abstract class JobModel {
               currentWorkers += workerPool.getNumWorkers();
             }
           }
+
+          Map<String, Object> userAgent = environment.getUserAgent();
+          sdkName = (String) userAgent.get("name");
       }
 
       startTime = job.getStartTime();

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -110,7 +110,8 @@ function addJobToTable(job, table) {
   tableRow.appendChild(jobStateTime);
 
   const jobSDK = document.createElement('td');
-  jobSDK.innerText = job.sdk + ' ' + job.sdkSupportStatus;
+  jobSDK.innerText = job.sdk + ' ' + job.sdkSupportStatus + ' ' +
+                         job.sdkName;
   tableRow.appendChild(jobSDK);
 
   const jobRegion = document.createElement('td');

--- a/src/test/java/com/google/sps/AggregationCenterTest.java
+++ b/src/test/java/com/google/sps/AggregationCenterTest.java
@@ -25,16 +25,16 @@ public final class AggregationCenterTest {
 
     private static final JobJSON JOB1 = new JobJSON(null, "beamsqldemopipeline-ihr-0804214611-d6c2f941", null,
                                                         null, "2.23.0", "SUPPORTED", "europe-west1", 0, null, null, null, null, 
-                                                            null, null, null, null, null, null, null, null);
+                                                            null, null, null, null, null, null, null, null, "Apache Beam SDK for Java");
     private static final JobJSON JOB2 = new JobJSON(null, "beamsqldemopipeline-ihr-0804213246-8dbbe1e9", null,
                                                         null, "2.23.0-SNAPSHOT", "STALE", "us-central1", 0, null, null, null, null, 
-                                                            null, null, null, null, null, null, null, null);
+                                                            null, null, null, null, null, null, null, null, null);
     private static final JobJSON JOB3 = new JobJSON(null, "otherName-otherUser-0804214611-d6c2f941", null,
                                                         null, "2.23.0", "SUPPORTED", "europe-west1", 0, null, null, null, null, 
-                                                            null, null, null, null, null, null, null, null);
+                                                            null, null, null, null, null, null, null, null, null);
     private static final JobJSON JOB4 = new JobJSON(null, "jobDoesn'tRespectNaming", null,
                                                         null, "2.23.0", "SUPPORTED", "europe-west2", 0, null, null, null, null, 
-                                                            null, null, null, null, null, null, null, null);
+                                                            null, null, null, null, null, null, null, null, null);
     
 
     @Before
@@ -201,6 +201,43 @@ public final class AggregationCenterTest {
       expectedMap.put("2.23.0-SNAPSHOT STALE", Arrays.asList(JOB2));
 
       Map<String, List<JobJSON>> actualMap = aggregationCenter.aggregateBySDK(jobs);
+     
+      Assert.assertEquals(expectedMap, actualMap);
+    }
+
+    @Test 
+    public void oneJobOneSDKSupportStatus() {
+      List<JobJSON> jobs = Arrays.asList(JOB1);
+
+      Map<String, List<JobJSON>> expectedMap = new HashMap<>();
+      expectedMap.put("SUPPORTED", jobs);
+
+      Map<String, List<JobJSON>> actualMap = aggregationCenter.aggregateBySDKSupportStatus(jobs);
+     
+      Assert.assertEquals(expectedMap, actualMap);
+    }
+
+    @Test 
+    public void multipleJobsMultipleSDKSupportStatus() {
+      List<JobJSON> jobs = Arrays.asList(JOB1, JOB2, JOB3, JOB4);
+
+      Map<String, List<JobJSON>> expectedMap = new HashMap<>();
+      expectedMap.put("SUPPORTED", Arrays.asList(JOB1, JOB3, JOB4));
+      expectedMap.put("STALE", Arrays.asList(JOB2));
+
+      Map<String, List<JobJSON>> actualMap = aggregationCenter.aggregateBySDKSupportStatus(jobs);
+     
+      Assert.assertEquals(expectedMap, actualMap);
+    }
+
+    @Test
+    public void oneJobOneProgrammingLanguage() {
+      List<JobJSON> jobs = Arrays.asList(JOB1);
+
+      Map<String, List<JobJSON>> expectedMap = new HashMap<>();
+      expectedMap.put("Java", jobs);
+
+      Map<String, List<JobJSON>> actualMap = aggregationCenter.aggregateByProgrammingLanguage(jobs);
      
       Assert.assertEquals(expectedMap, actualMap);
     }


### PR DESCRIPTION
1. Add JobModel and JobJSON a field that contains the name of the SDK used (that also contains the name of the programming language) and add the instructions to fetch this data in the JobModel Constructor. 
2. Modify JobsServlet to store to DataStore this new data fetched.
3. Added aggregateByProgrammingLanguage to Agregation Center that group the jobs based on the language found and designed unit test for it
4. Make the code more modularized in AggregationCenter class (aggregate the jobs based on a key generated as needed) - added an interface (KeyGenerator) that deals with generating the key and use various implementations of this interface when calling aggregateBy