### PR TITLE
Update the information already existing instead of fetching everything again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,14 @@
           <deploy.version>1</deploy.version>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.7.2</version>
+        <configuration>
+            <workingDirectory>${project.build.directory}/capstone-project-1</workingDirectory>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/main/java/com/google/sps/JobStoreCenter.java
+++ b/src/main/java/com/google/sps/JobStoreCenter.java
@@ -134,8 +134,8 @@ public final class JobStoreCenter {
     Double totalMemoryTime = (Double) entity.getProperty("totalMemoryTime"); 
     Double totalDiskTimeHDD = (Double) entity.getProperty("totalDiskTimeHDD");
     Double totalDiskTimeSSD = (Double) entity.getProperty("totalDiskTimeSSD");
-    Long longCurrentVcouCount = (Long) entity.getProperty("currentVcpuCount");
-    Integer currentVcpuCount = longCurrentVcouCount == null? null : longCurrentVcouCount.intValue();
+    Long longCurrentVcpuCount = (Long) entity.getProperty("currentVcpuCount");
+    Integer currentVcpuCount = longCurrentVcpuCount == null? null : longCurrentVcpuCount.intValue();
     Double totalStreamingData = (Double) entity.getProperty("totalStreamingData"); 
     Boolean enableStreamingEngine = (Boolean) entity.getProperty("enableStreamingEngine");
     String metricTime = (String) entity.getProperty("metricTime");

--- a/src/main/java/com/google/sps/JobStoreCenter.java
+++ b/src/main/java/com/google/sps/JobStoreCenter.java
@@ -27,6 +27,9 @@ import java.time.Clock;
 import java.util.List;
 import java.util.ArrayList;
 import com.google.sps.data.JobJSON;
+import com.google.sps.data.Project;
+import com.google.appengine.api.datastore.EntityNotFoundException;
+import com.google.api.services.dataflow.model.Job;
 
 // Class that deals with the interaction with Datastore 
 public final class JobStoreCenter {
@@ -109,37 +112,159 @@ public final class JobStoreCenter {
       PreparedQuery resultsJobs = datastore.prepare(queryJobs);
 
       for (Entity entity : resultsJobs.asIterable()) {
-        String name = (String) entity.getProperty("name");
-        String id = (String) entity.getProperty("jobId");
-        String type = (String) entity.getProperty("type");
-        String sdk = (String) entity.getProperty("sdk");
-        String sdkSupportStatus = (String) entity.getProperty("sdkSupportStatus");
-        String region = (String) entity.getProperty("region");
-        int currentWorkers = ((Long) entity.getProperty("currentWorkers")).intValue();
-        String startTime = (String) entity.getProperty("startTime");
-        Double totalVCPUTime = (Double) entity.getProperty("totalVCPUTime"); 
-        Double totalMemoryTime = (Double) entity.getProperty("totalMemoryTime"); 
-        Double totalDiskTimeHDD = (Double) entity.getProperty("totalDiskTimeHDD");
-        Double totalDiskTimeSSD = (Double) entity.getProperty("totalDiskTimeSSD");
-        Long longCurrentVcouCount = (Long) entity.getProperty("currentVcpuCount");
-        Integer currentVcpuCount = longCurrentVcouCount == null? null : longCurrentVcouCount.intValue();
-        Double totalStreamingData = (Double) entity.getProperty("totalStreamingData"); 
-        Boolean enableStreamingEngine = (Boolean) entity.getProperty("enableStreamingEngine");
-        String metricTime = (String) entity.getProperty("metricTime");
-        String state = (String) entity.getProperty("state");
-        String stateTime = (String) entity.getProperty("stateTime");
-        Double price = (Double) entity.getProperty("price");
-        String sdkName = (String) entity.getProperty("sdkName");
-
-        JobJSON job = new JobJSON(projectId, name, id, type, sdk, sdkSupportStatus, region, 
-                                     currentWorkers, startTime, totalVCPUTime, totalMemoryTime,
-                                        totalDiskTimeHDD, totalDiskTimeSSD, currentVcpuCount,
-                                            totalStreamingData, enableStreamingEngine, metricTime,
-                                                state, stateTime, price, sdkName);
-        
+        JobJSON job = convertEntityToJobJSON(entity);
+    
         jobs.add(job);
       }
 
       return jobs;
+  }
+
+  private JobJSON convertEntityToJobJSON(Entity entity) {
+    String projectId = (String) entity.getProperty("projectId");
+    String name = (String) entity.getProperty("name");
+    String id = (String) entity.getProperty("jobId");
+    String type = (String) entity.getProperty("type");
+    String sdk = (String) entity.getProperty("sdk");
+    String sdkSupportStatus = (String) entity.getProperty("sdkSupportStatus");
+    String region = (String) entity.getProperty("region");
+    int currentWorkers = ((Long) entity.getProperty("currentWorkers")).intValue();
+    String startTime = (String) entity.getProperty("startTime");
+    Double totalVCPUTime = (Double) entity.getProperty("totalVCPUTime"); 
+    Double totalMemoryTime = (Double) entity.getProperty("totalMemoryTime"); 
+    Double totalDiskTimeHDD = (Double) entity.getProperty("totalDiskTimeHDD");
+    Double totalDiskTimeSSD = (Double) entity.getProperty("totalDiskTimeSSD");
+    Long longCurrentVcouCount = (Long) entity.getProperty("currentVcpuCount");
+    Integer currentVcpuCount = longCurrentVcouCount == null? null : longCurrentVcouCount.intValue();
+    Double totalStreamingData = (Double) entity.getProperty("totalStreamingData"); 
+    Boolean enableStreamingEngine = (Boolean) entity.getProperty("enableStreamingEngine");
+    String metricTime = (String) entity.getProperty("metricTime");
+    String state = (String) entity.getProperty("state");
+    String stateTime = (String) entity.getProperty("stateTime");
+    Double price = (Double) entity.getProperty("price");
+    String sdkName = (String) entity.getProperty("sdkName");
+
+    JobJSON job = new JobJSON(projectId, name, id, type, sdk, sdkSupportStatus, region, 
+                                  currentWorkers, startTime, totalVCPUTime, totalMemoryTime,
+                                      totalDiskTimeHDD, totalDiskTimeSSD, currentVcpuCount,
+                                          totalStreamingData, enableStreamingEngine, metricTime,
+                                              state, stateTime, price, sdkName);
+    return job;
+  }
+
+  public Entity fetchProject(String projectId)  {
+      Entity project = null;
+      Key projectKey = KeyFactory.createKey("Project", projectId);
+      try{
+        project = datastore.get(projectKey);
+      } catch (EntityNotFoundException e) {
+        System.out.println("JobNotFound");
+        return null;
+      }
+
+      return project;
+  }
+  
+  // Updates a project. The project must already exist 
+  public void updateProject(String projectId, String pathToJsonFile, Entity project) throws IOException , GeneralSecurityException {
+    ProjectCenter projectCenter = new ProjectCenter(projectId, pathToJsonFile);
+
+    String lastTimeAccessedString = (String) project.getProperty("lastAccessed");
+    Instant lastTimeAccessed = Instant.parse(lastTimeAccessedString);
+
+    project.setProperty("lastAccessed", java.time.Clock.systemUTC().instant().toString());
+    datastore.put(project);
+
+    List<JobModel> allJobs = projectCenter.fetchJobsforUpdate(lastTimeAccessedString);
+    for (JobModel job : allJobs) {
+      String time = job.stateTime;
+      Instant stateTime = Instant.parse(time);
+      
+      // The state was changed after our last fetch
+      if (stateTime.compareTo(lastTimeAccessed) > 0) {
+        // A FinalisedJob can't have its state modified, so the job
+        // must have Running the last time the Datastore was updated
+
+        // Delete the RunningJob job in DataStore
+        Key k =
+            new KeyFactory.Builder("Project", projectId)
+              .addChild("RunningJob", job.id)
+              .getKey();
+        datastore.delete(k);
+
+        // Add the new Job
+        JobModel updatedJob = projectCenter.fetch(job.id, job.region);
+        if (updatedJob instanceof RunningJob) {
+          addJobToDatastore((RunningJob)updatedJob, project);
+        } else {
+          addJobToDatastore((FinalisedJob)updatedJob, project);
+        }
+      } else {
+        if (job.updated) {
+          updateJobToDatastore(job, projectId, project, projectCenter);
+        }
+      }
+    }     
+  }
+ 
+ // Changes only the fields that were modified
+  private void updateJobToDatastore (JobModel updatedJob, String projectId, Entity project, 
+      ProjectCenter projectCenter) throws IOException {
+    // Only Running Jobs can be updated
+    Key k =
+        new KeyFactory.Builder("Project", projectId)
+            .addChild("RunningJob", updatedJob.id)
+            .getKey();
+    Entity jobEntity;
+    try{
+      jobEntity = datastore.get(k);  
+      if (updatedJob.totalVCPUTime != null) {
+        jobEntity.setProperty("totalVCPUTime", updatedJob.totalVCPUTime);
+      }
+      if (updatedJob.totalMemoryTime != null) {
+        jobEntity.setProperty("totalMemoryTime", updatedJob.totalMemoryTime);
+      }
+      if (updatedJob.totalDiskTimeHDD != null) {
+        jobEntity.setProperty("totalDiskTimeHDD", updatedJob.totalDiskTimeHDD);
+      }
+      if (updatedJob.totalDiskTimeSSD != null) {
+        jobEntity.setProperty("totalDiskTimeSSD", updatedJob.totalDiskTimeSSD);
+      }
+      if (updatedJob.currentVcpuCount != null) {
+        jobEntity.setProperty("currentVcpuCount", updatedJob.currentVcpuCount);
+      }
+      if (updatedJob.totalStreamingData != null) {
+        jobEntity.setProperty("totalStreamingData", updatedJob.totalStreamingData);
+      }
+      if (updatedJob.enableStreamingEngine != null) {
+        jobEntity.setProperty("enableStreamingEngine", updatedJob.enableStreamingEngine);
+      }
+
+      PriceCenter priceCenter = new PriceCenter();
+      jobEntity.setProperty("price", priceCenter.calculatePrice(convertEntityToJobJSON(jobEntity)));
+
+      datastore.put(jobEntity);
+
+      } catch (EntityNotFoundException e) {
+        // The Job doesn't exist
+        JobModel newjob = projectCenter.fetch(updatedJob.id, updatedJob.region);
+        if (updatedJob instanceof RunningJob) {
+          addJobToDatastore((RunningJob)updatedJob, project);
+        } else {
+          addJobToDatastore((FinalisedJob)updatedJob, project);
+        }
+      }
+  }
+  
+  // Function that creates the new project in Datastore if the project doesn t already
+  // exist or updates the existing project
+  public void dealWithProject(String projectId, String pathToJsonFile) throws IOException , GeneralSecurityException {
+    Entity project = fetchProject(projectId);
+
+    if (project == null) {
+      addNewProject(projectId, pathToJsonFile);
+    } else {
+      updateProject(projectId, pathToJsonFile, project);
+    }
   }
 }

--- a/src/main/java/com/google/sps/PriceCenter.java
+++ b/src/main/java/com/google/sps/PriceCenter.java
@@ -7,6 +7,7 @@
 package com.google.sps;
 
 import com.google.sps.data.JobModel;
+import com.google.sps.data.JobJSON;
 
 // Calculates the price for a job   
 public final class PriceCenter {
@@ -23,36 +24,69 @@ public final class PriceCenter {
   private double streamingProcessedGB = 0.018;
 
   public double calculatePrice(JobModel job) {
-      double price = 0;
-      if (job.type.compareTo("JOB_TYPE_STREAMING") == 0) {
-        if (job.totalVCPUTime != null)
-          price += (job.totalVCPUTime / 3600) * streamingCPUhour;
-        if (job.totalMemoryTime != null)
-          price += (job.totalMemoryTime / (3600 * 1024)) * streamingMemoryGBHour;
-        if (job.totalDiskTimeHDD != null)
-          price += (job.totalDiskTimeHDD / 3600) * streamingHDDGBHour;
-        if (job.totalDiskTimeSSD != null)
-          price += (job.totalDiskTimeSSD / 3600) * streamingSSDGBHour;
-        if (job.enableStreamingEngine) {
-            price += job.totalStreamingData * streamingProcessedGB;
-        }
+    double price = 0;
+    if (job.type.compareTo("JOB_TYPE_STREAMING") == 0) {
+      if (job.totalVCPUTime != null)
+        price += (job.totalVCPUTime / 3600) * streamingCPUhour;
+      if (job.totalMemoryTime != null)
+        price += (job.totalMemoryTime / (3600 * 1024)) * streamingMemoryGBHour;
+      if (job.totalDiskTimeHDD != null)
+        price += (job.totalDiskTimeHDD / 3600) * streamingHDDGBHour;
+      if (job.totalDiskTimeSSD != null)
+        price += (job.totalDiskTimeSSD / 3600) * streamingSSDGBHour;
+      if (job.enableStreamingEngine) {
+        price += job.totalStreamingData * streamingProcessedGB;
       }
+    }
 
-      if (job.type.compareTo("JOB_TYPE_BATCH") == 0) {
-        if (job.totalVCPUTime != null)
-          price += (job.totalVCPUTime / 3600) * batchCPUhour;
-        if (job.totalMemoryTime != null)
-          price += (job.totalMemoryTime / (3600 * 1024)) * batchMemoryGBHour;
-        if (job.totalDiskTimeHDD != null)
-          price += (job.totalDiskTimeHDD / 3600) * batchHDDGBHour;
-        if (job.totalDiskTimeSSD != null)
-          price += (job.totalDiskTimeSSD / 3600) * batchSSDGBHour;
-        if (job.enableStreamingEngine) {
-            price += job.totalStreamingData * batchProcessedGB;
-        }
+    if (job.type.compareTo("JOB_TYPE_BATCH") == 0) {
+      if (job.totalVCPUTime != null)
+        price += (job.totalVCPUTime / 3600) * batchCPUhour;
+      if (job.totalMemoryTime != null)
+        price += (job.totalMemoryTime / (3600 * 1024)) * batchMemoryGBHour;
+      if (job.totalDiskTimeHDD != null)
+        price += (job.totalDiskTimeHDD / 3600) * batchHDDGBHour;
+      if (job.totalDiskTimeSSD != null)
+        price += (job.totalDiskTimeSSD / 3600) * batchSSDGBHour;
+      if (job.enableStreamingEngine) {
+        price += job.totalStreamingData * batchProcessedGB;
       }
+    }
 
-      return price;
+    return price;
+  }
+
+  public double calculatePrice(JobJSON job) {
+    double price = 0;
+    if (job.type.compareTo("JOB_TYPE_STREAMING") == 0) {
+      if (job.totalVCPUTime != null)
+        price += (job.totalVCPUTime / 3600) * streamingCPUhour;
+      if (job.totalMemoryTime != null)
+        price += (job.totalMemoryTime / (3600 * 1024)) * streamingMemoryGBHour;
+      if (job.totalDiskTimeHDD != null)
+        price += (job.totalDiskTimeHDD / 3600) * streamingHDDGBHour;
+      if (job.totalDiskTimeSSD != null)
+        price += (job.totalDiskTimeSSD / 3600) * streamingSSDGBHour;
+      if (job.enableStreamingEngine) {
+        price += job.totalStreamingData * streamingProcessedGB;
+      }
+    }
+
+    if (job.type.compareTo("JOB_TYPE_BATCH") == 0) {
+      if (job.totalVCPUTime != null)
+        price += (job.totalVCPUTime / 3600) * batchCPUhour;
+      if (job.totalMemoryTime != null)
+        price += (job.totalMemoryTime / (3600 * 1024)) * batchMemoryGBHour;
+      if (job.totalDiskTimeHDD != null)
+        price += (job.totalDiskTimeHDD / 3600) * batchHDDGBHour;
+      if (job.totalDiskTimeSSD != null)
+        price += (job.totalDiskTimeSSD / 3600) * batchSSDGBHour;
+      if (job.enableStreamingEngine) {
+        price += job.totalStreamingData * batchProcessedGB;
+      }
+    }
+
+    return price;
   }
 
 

--- a/src/main/java/com/google/sps/ProjectCenter.java
+++ b/src/main/java/com/google/sps/ProjectCenter.java
@@ -126,4 +126,21 @@ public final class ProjectCenter {
 
       return null;
     }
+
+    public List<JobModel> fetchJobsforUpdate(String lastUpdate) throws IOException {
+      Dataflow.Projects.Jobs.Aggregated request = dataflowService.projects().jobs().aggregated(projectId);
+      ListJobsResponse response;
+      ArrayList<JobModel> jobs = new ArrayList<>();
+      do {
+        response = request.execute();
+        
+        for (Job job : response.getJobs()) {
+          jobs.add(JobModel.updateJob(projectId, job, dataflowService, lastUpdate));
+        }
+        
+        request.setPageToken(response.getNextPageToken());
+      } while (response.getNextPageToken() != null);
+
+      return jobs; 
+    }
 }

--- a/src/main/java/com/google/sps/data/FinalisedJob.java
+++ b/src/main/java/com/google/sps/data/FinalisedJob.java
@@ -27,4 +27,11 @@ public final class FinalisedJob extends JobModel {
         state = job.getCurrentState();
         stateTime = job.getCurrentStateTime();
     }
+
+    public FinalisedJob(String projectId, String id, String state, String stateTime, String region) throws IOException, IllegalArgumentException {
+      super(projectId, id, region);
+
+      this.state = state;
+      this.stateTime = stateTime;
+    }
 }

--- a/src/main/java/com/google/sps/data/JobModel.java
+++ b/src/main/java/com/google/sps/data/JobModel.java
@@ -54,11 +54,24 @@ public abstract class JobModel {
     public Double totalStreamingData = null; //GB - multiply by 1024 for MB
     public Boolean enableStreamingEngine = false;
     public String metricTime = null;
+    public Boolean updated = false;
 
     // Possible states can be found at 
     // https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.jobs#jobstate
     public String state;
     public String stateTime;
+
+    public JobModel(String projectId, String id, String region) {
+      this.projectId = projectId;
+      this.id = id;
+
+      name = null;
+      type = null;
+      sdkName = null;
+      region = region;
+      startTime = null;
+      enableStreamingEngine = null;
+    }
 
     public JobModel(String projectId, Job job, Dataflow dataflowService) throws IOException, IllegalArgumentException {
       this.projectId = projectId;
@@ -90,14 +103,15 @@ public abstract class JobModel {
 
       startTime = job.getStartTime();
 
-      getMetrics(dataflowService);
+      getMetrics(dataflowService, null);
     }
 
-    private void getMetrics(Dataflow dataflowService) throws IOException, IllegalArgumentException {
+    private void getMetrics(Dataflow dataflowService, String startTime) throws IOException, IllegalArgumentException {
       Dataflow.Projects.Locations.Jobs.GetMetrics request2 = dataflowService.projects()
       .locations()
       .jobs()
       .getMetrics(projectId, region, id);
+      request2.setStartTime(startTime);
       JobMetrics jobMetric = request2.execute();
 
       metricTime = jobMetric.getMetricTime();
@@ -111,17 +125,23 @@ public abstract class JobModel {
           String metricName = metric.getName().getName();
           if (metricName.compareTo("TotalVcpuTime") == 0) {
             totalVCPUTime = ((BigDecimal) metric.getScalar()).doubleValue();
+            updated = true;
           } else if (metricName.compareTo("TotalMemoryUsage") == 0) {
             totalMemoryTime = ((BigDecimal) metric.getScalar()).doubleValue();
+            updated = true;
           } else if (metricName.compareTo("TotalPdUsage") == 0 ) {
             totalDiskTimeHDD = ((BigDecimal) metric.getScalar()).doubleValue();
+            updated = true;
           } else if (metricName.compareTo("TotalSsdUsage") == 0 ) {
             totalDiskTimeSSD = ((BigDecimal) metric.getScalar()).doubleValue();
+            updated = true;
           } else if (metricName.compareTo("CurrentVcpuCount") == 0) {
             currentVcpuCount = ((BigDecimal) metric.getScalar()).intValue();
+            updated = true;
           } else if (metricName.compareTo("TotalStreamingDataProcessed") == 0) {
             totalStreamingData = ((BigDecimal) metric.getScalar()).doubleValue();
             enableStreamingEngine = true;
+            updated = true;
           }
         }
       }    
@@ -129,17 +149,38 @@ public abstract class JobModel {
 
     public static JobModel createJob(String projectId, Job job, Dataflow dataflowService)
         throws IOException, IllegalArgumentException {
-            String state = job.getCurrentState();
-            if (state.compareTo("JOB_STATE_UNKNOWN") == 0 
-                   || state.compareTo("JOB_STATE_STOPPED") == 0
-                   || state.compareTo("JOB_STATE_RUNNING") == 0
-                   || state.compareTo("JOB_STATE_DRAINING") == 0
-                   || state.compareTo("JOB_STATE_PENDING") == 0
-                   || state.compareTo("JOB_STATE_CANCELLING") == 0
-                   || state.compareTo("JOB_STATE_QUEUED") == 0) {
-              return new RunningJob(projectId, job, dataflowService);
-            } else {
-                return new FinalisedJob(projectId, job, dataflowService);
-            }
-        }
+      String state = job.getCurrentState();
+      if (state.compareTo("JOB_STATE_UNKNOWN") == 0 
+             || state.compareTo("JOB_STATE_STOPPED") == 0
+             || state.compareTo("JOB_STATE_RUNNING") == 0
+             || state.compareTo("JOB_STATE_DRAINING") == 0
+             || state.compareTo("JOB_STATE_PENDING") == 0
+             || state.compareTo("JOB_STATE_CANCELLING") == 0
+             || state.compareTo("JOB_STATE_QUEUED") == 0) {
+        return new RunningJob(projectId, job, dataflowService);
+      } else {
+        return new FinalisedJob(projectId, job, dataflowService);
+      }
+    }
+
+    public static JobModel updateJob(String projectId, Job job, Dataflow dataflowService, String lastModified) 
+        throws IOException, IllegalArgumentException {
+      JobModel updatedJob;
+      String state = job.getCurrentState();
+      if (state.compareTo("JOB_STATE_UNKNOWN") == 0 
+             || state.compareTo("JOB_STATE_STOPPED") == 0
+             || state.compareTo("JOB_STATE_RUNNING") == 0
+             || state.compareTo("JOB_STATE_DRAINING") == 0
+             || state.compareTo("JOB_STATE_PENDING") == 0
+             || state.compareTo("JOB_STATE_CANCELLING") == 0
+             || state.compareTo("JOB_STATE_QUEUED") == 0) {
+        updatedJob =  new RunningJob(projectId, job.getId(), job.getCurrentState(), job.getCurrentStateTime(), job.getLocation());
+      } else {
+        updatedJob = new FinalisedJob(projectId, job.getId(), job.getCurrentState(), job.getCurrentStateTime(), job.getLocation());
+      }
+
+      updatedJob.getMetrics(dataflowService, lastModified);
+
+      return updatedJob;
+    }
 }

--- a/src/main/java/com/google/sps/data/RunningJob.java
+++ b/src/main/java/com/google/sps/data/RunningJob.java
@@ -30,4 +30,11 @@ public final class RunningJob extends JobModel {
         state = job.getCurrentState();
         stateTime = job.getCurrentStateTime();
     }
+
+    public RunningJob(String projectId, String id, String state, String stateTime, String region) throws IOException, IllegalArgumentException {
+      super(projectId, id, region);
+
+      this.state = state;
+      this.stateTime = stateTime;
+    }
 }

--- a/src/main/java/com/google/sps/servlets/JobsServlet.java
+++ b/src/main/java/com/google/sps/servlets/JobsServlet.java
@@ -51,7 +51,7 @@ public class JobsServlet extends HttpServlet {
       JobStoreCenter jobCenter = new JobStoreCenter();
 
       try{
-        jobCenter.addNewProject(projectId, pathToJsonFile);
+        jobCenter.dealWithProject(projectId, pathToJsonFile);
       } catch (GeneralSecurityException e) {
         System.out.println("Unable to initialize service: \n" + e.toString());
         return;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -277,6 +277,7 @@ tr:nth-child(even) {
 .sdkAnalysis {
   grid-column: 1;
   grid-row: row 3;
+  background-color: papayawhip;
 }
 
 .sdkTitle {


### PR DESCRIPTION
1. Add in JobStoreCenter function convertEntityToJobJSON that takes an entity and returns a JobJSON with all the fields written accordingly --> helps with modularizing the programm.
2. Add in JobStoreCenter the possibility to fetch the project from Datastore
3. Add in JobStoreCenter updateJobtoDatastore that only changes the fields of a job that have been modified. If a field has't been modified, its value its null. Only metric fields and state can be modified, so these are the only fields investigated
4. Add in JobStoreCenter method dealWIthProject which decides if the project should be updated (if it already exists) or it should be created.
5. Add in JobModel fetchJobsforUpdate that returns a list with updated jobs (jobs that have unmodified fields null)
