### PR TITLE
Separate fetching a job from a server from the rest of the implementation

### DIFF
--- a/src/main/java/com/google/sps/data/FetchJobFromServer.java
+++ b/src/main/java/com/google/sps/data/FetchJobFromServer.java
@@ -1,0 +1,164 @@
+// Copyright 2020 Google LLC
+
+/**
+ * @author andreeanica
+ */
+
+package com.google.sps.data;
+
+import com.google.api.services.dataflow.Dataflow;
+import com.google.api.services.dataflow.model.Job;
+import com.google.api.services.dataflow.model.JobMetadata;
+import com.google.api.services.dataflow.model.SdkVersion;
+import com.google.api.services.dataflow.model.Environment;
+import com.google.api.services.dataflow.model.WorkerPool;
+import com.google.api.services.dataflow.model.JobMetrics;
+import com.google.api.services.dataflow.model.MetricUpdate;
+import java.io.IOException;
+import java.lang.IllegalArgumentException;
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.List;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+
+// Class FetchJobFromServer fetches the necessary information from the 
+// server. Class used in the acgtual implementation of the web application
+public class FetchJobFromServer implements FetchJobInfo {
+  private Job job;
+  private Environment environment;
+  private SdkVersion sdkVersion;
+  private Dataflow dataflowService;
+
+  public FetchJobFromServer(Job job, Dataflow dataflowService) {
+    this.job = job;
+    environment = job.getEnvironment();
+    sdkVersion = job.getJobMetadata().getSdkVersion(); 
+    this.dataflowService = dataflowService;
+  }
+
+  public String getName() {
+    return job.getName();
+  }
+
+  public String getId() {
+    return job.getId();
+  }
+
+  public String getType() {
+    return job.getType();
+  }
+
+  public String getSdk() {
+    if (sdkVersion != null) {
+      return sdkVersion.getVersion();
+    } else {
+      return null;
+    }
+  }
+
+  public String getSdkSupportStatus() {
+    if (sdkVersion != null) {
+      return sdkVersion.getSdkSupportStatus();
+    } else {
+      return null;
+    }  
+  }
+
+  public String getRegion() {
+    return job.getLocation();
+  }
+
+  public int getCurrentWorkers() {
+    int currentWorkers = 0;
+    if (environment != null) {
+      List<WorkerPool> workerPoolList = environment.getWorkerPools();
+      if (workerPoolList != null) {
+        for (WorkerPool workerPool : workerPoolList) {
+          currentWorkers += workerPool.getNumWorkers();
+        }
+      }
+    }
+
+    return currentWorkers;
+  }
+
+  public String getSdkName() {
+    if (environment != null) {
+      Map<String, Object> userAgent = environment.getUserAgent();
+      return (String) userAgent.get("name");
+    } else {
+      return null;
+    }
+  }
+
+  public String getStartTime() {
+    return job.getStartTime();
+  }
+
+  public String getState() {
+    return job.getCurrentState();
+  }
+
+  public String getStateTime() {
+    return job.getCurrentStateTime();
+  }
+
+  public void setMetrics(JobModel jobModel, String startTime) throws IOException, IllegalArgumentException {
+    Dataflow.Projects.Locations.Jobs.GetMetrics request2 = dataflowService.projects()
+      .locations()
+      .jobs()
+      .getMetrics(jobModel.projectId, jobModel.region, jobModel.id);
+      request2.setStartTime(startTime);
+
+    JobMetrics jobMetric;
+
+    try {
+      jobMetric = request2.execute();
+    } catch (GoogleJsonResponseException e) {
+      // The job is no longer saved in the system, so we can't fetch any metric
+      return;
+    }
+
+    jobModel.metricTime = jobMetric.getMetricTime();
+
+    if (jobMetric != null) {
+      // The job has failed, so it has no metrics
+      if (jobMetric.getMetrics() == null) {
+        return;
+      }
+
+      for (MetricUpdate metric : jobMetric.getMetrics()) {
+        String metricName = metric.getName().getName();
+        if (metricName.compareTo("TotalVcpuTime") == 0) {
+          jobModel.totalVCPUTime = ((BigDecimal) metric.getScalar()).doubleValue();
+          jobModel.updated = true;
+        } else if (metricName.compareTo("TotalMemoryUsage") == 0) {
+          jobModel.totalMemoryTime = ((BigDecimal) metric.getScalar()).doubleValue();
+          jobModel.updated = true;
+        } else if (metricName.compareTo("TotalPdUsage") == 0 ) {
+          jobModel.totalDiskTimeHDD = ((BigDecimal) metric.getScalar()).doubleValue();
+          jobModel.updated = true;
+        } else if (metricName.compareTo("TotalSsdUsage") == 0 ) {
+          jobModel.totalDiskTimeSSD = ((BigDecimal) metric.getScalar()).doubleValue();
+          jobModel.updated = true;
+        } else if (metricName.compareTo("CurrentVcpuCount") == 0) {
+          jobModel.currentVcpuCount = ((BigDecimal) metric.getScalar()).intValue();
+          jobModel.updated = true;
+        } else if (metricName.compareTo("TotalStreamingDataProcessed") == 0) {
+          jobModel.totalStreamingData = ((BigDecimal) metric.getScalar()).doubleValue();
+          jobModel.enableStreamingEngine = true;
+          jobModel.updated = true;
+        } else if (metricName.compareTo("CurrentMemoryUsage") == 0) {
+          jobModel.currentMemoryUsage = ((BigDecimal) metric.getScalar()).doubleValue();
+          jobModel.updated = true;
+        } else if (metricName.compareTo("CurrentPdUsage") == 0) {
+          jobModel.currentPdUsage = ((BigDecimal) metric.getScalar()).doubleValue();
+          jobModel.updated = true;
+          } else if (metricName.compareTo("CurrentSsdUsage") == 0) {
+          jobModel.currentSsdUsage = ((BigDecimal) metric.getScalar()).doubleValue();
+          jobModel.updated = true;
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/com/google/sps/data/FetchJobInfo.java
+++ b/src/main/java/com/google/sps/data/FetchJobInfo.java
@@ -1,0 +1,30 @@
+// Copyright 2020 Google LLC
+
+/**
+ * @author andreeanica
+ */
+
+package com.google.sps.data;
+
+import com.google.api.services.dataflow.model.Job;
+import java.io.IOException;
+import java.lang.IllegalArgumentException;
+
+// Interface designed to separate fetching from the JobModel implementation
+// to make it possible to test
+public interface FetchJobInfo {
+  String getName();
+  String getId();
+  String getType();
+  String getSdk();
+  String getSdkSupportStatus();
+  String getRegion();
+  int getCurrentWorkers();
+  String getSdkName();
+  String getStartTime();
+  String getState();
+  String getStateTime();
+
+  // Modify the job provided as parameter, setting the metrics in it
+  void setMetrics(JobModel job, String startTime) throws IOException, IllegalArgumentException;
+}

--- a/src/main/java/com/google/sps/data/FinalisedJob.java
+++ b/src/main/java/com/google/sps/data/FinalisedJob.java
@@ -21,11 +21,11 @@ import java.lang.IllegalArgumentException;
 // - JOB_STATE_UPDATED
 // - JOB_STATE_DRAINED
 public final class FinalisedJob extends JobModel {
-    public FinalisedJob(String projectId, Job job, Dataflow dataflowService) throws IOException, IllegalArgumentException {
-        super(projectId, job, dataflowService);
+    public FinalisedJob(String projectId, FetchJobInfo fetchJobInfo) throws IOException, IllegalArgumentException {
+        super(projectId, fetchJobInfo);
 
-        state = job.getCurrentState();
-        stateTime = job.getCurrentStateTime();
+        state = fetchJobInfo.getState();
+        stateTime = fetchJobInfo.getStateTime();
     }
 
     public FinalisedJob(String projectId, String id, String state, String stateTime, String region) throws IOException, IllegalArgumentException {

--- a/src/main/java/com/google/sps/data/JobModel.java
+++ b/src/main/java/com/google/sps/data/JobModel.java
@@ -75,98 +75,24 @@ public abstract class JobModel {
       enableStreamingEngine = null;
     }
 
-    public JobModel(String projectId, Job job, Dataflow dataflowService) throws IOException, IllegalArgumentException {
+    public JobModel(String projectId, FetchJobInfo fetchJobInfo) throws IOException, IllegalArgumentException {
       this.projectId = projectId;
-      name = job.getName();
-      id = job.getId();
-      type = job.getType();
-      
-      SdkVersion sdkVersion = job.getJobMetadata().getSdkVersion();
-      if (sdkVersion != null) {
-          sdk = sdkVersion.getVersion();
-          sdkSupportStatus =  sdkVersion.getSdkSupportStatus();
-      }
+      name = fetchJobInfo.getName();
+      id = fetchJobInfo.getId();
+      type = fetchJobInfo.getType();
+      sdk = fetchJobInfo.getSdk();
+      sdkSupportStatus =  fetchJobInfo.getSdkSupportStatus();
+      region = fetchJobInfo.getRegion();
+      currentWorkers = fetchJobInfo.getCurrentWorkers();
+      sdkName = fetchJobInfo.getSdkName();
+      startTime = fetchJobInfo.getStartTime();
 
-      region = job.getLocation();
-
-      Environment environment = job.getEnvironment();
-      if (environment != null) {
-          currentWorkers = 0;
-          List<WorkerPool> workerPoolList = environment.getWorkerPools();
-          if (workerPoolList != null) {
-            for (WorkerPool workerPool : workerPoolList) {
-              currentWorkers += workerPool.getNumWorkers();
-            }
-          }
-
-          Map<String, Object> userAgent = environment.getUserAgent();
-          sdkName = (String) userAgent.get("name");
-      }
-
-      startTime = job.getStartTime();
-
-      getMetrics(dataflowService, null);
+      fetchJobInfo.setMetrics(this, null);
     }
 
-    private void getMetrics(Dataflow dataflowService, String startTime) throws IOException, IllegalArgumentException {
-      Dataflow.Projects.Locations.Jobs.GetMetrics request2 = dataflowService.projects()
-      .locations()
-      .jobs()
-      .getMetrics(projectId, region, id);
-      request2.setStartTime(startTime);
-      JobMetrics jobMetric;
-      try {
-        jobMetric = request2.execute();
-      } catch (GoogleJsonResponseException e) {
-          // The job is no longer saved in the system, so we can fetch any metrics
-          return;
-      }
-
-      metricTime = jobMetric.getMetricTime();
-
-      if (jobMetric != null) {
-        // The job has failed, so it has no metrics
-        if (jobMetric.getMetrics() == null) {
-          return;
-        } 
-        for (MetricUpdate metric : jobMetric.getMetrics()) {
-          String metricName = metric.getName().getName();
-          if (metricName.compareTo("TotalVcpuTime") == 0) {
-            totalVCPUTime = ((BigDecimal) metric.getScalar()).doubleValue();
-            updated = true;
-          } else if (metricName.compareTo("TotalMemoryUsage") == 0) {
-            totalMemoryTime = ((BigDecimal) metric.getScalar()).doubleValue();
-            updated = true;
-          } else if (metricName.compareTo("TotalPdUsage") == 0 ) {
-            totalDiskTimeHDD = ((BigDecimal) metric.getScalar()).doubleValue();
-            updated = true;
-          } else if (metricName.compareTo("TotalSsdUsage") == 0 ) {
-            totalDiskTimeSSD = ((BigDecimal) metric.getScalar()).doubleValue();
-            updated = true;
-          } else if (metricName.compareTo("CurrentVcpuCount") == 0) {
-            currentVcpuCount = ((BigDecimal) metric.getScalar()).intValue();
-            updated = true;
-          } else if (metricName.compareTo("TotalStreamingDataProcessed") == 0) {
-            totalStreamingData = ((BigDecimal) metric.getScalar()).doubleValue();
-            enableStreamingEngine = true;
-            updated = true;
-          } else if (metricName.compareTo("CurrentMemoryUsage") == 0) {
-            currentMemoryUsage = ((BigDecimal) metric.getScalar()).doubleValue();
-            updated = true;
-          } else if (metricName.compareTo("CurrentPdUsage") == 0) {
-            currentPdUsage = ((BigDecimal) metric.getScalar()).doubleValue();
-            updated = true;
-          } else if (metricName.compareTo("CurrentSsdUsage") == 0) {
-            currentSsdUsage = ((BigDecimal) metric.getScalar()).doubleValue();
-            updated = true;
-          }
-        }
-      }    
-    }
-
-    public static JobModel createJob(String projectId, Job job, Dataflow dataflowService)
+    public static JobModel createJob(String projectId, FetchJobInfo fetchJobInfo)
         throws IOException, IllegalArgumentException {
-      String state = job.getCurrentState();
+      String state = fetchJobInfo.getState();
       if (state.compareTo("JOB_STATE_UNKNOWN") == 0 
              || state.compareTo("JOB_STATE_STOPPED") == 0
              || state.compareTo("JOB_STATE_RUNNING") == 0
@@ -174,16 +100,17 @@ public abstract class JobModel {
              || state.compareTo("JOB_STATE_PENDING") == 0
              || state.compareTo("JOB_STATE_CANCELLING") == 0
              || state.compareTo("JOB_STATE_QUEUED") == 0) {
-        return new RunningJob(projectId, job, dataflowService);
+        return new RunningJob(projectId, fetchJobInfo);
       } else {
-        return new FinalisedJob(projectId, job, dataflowService);
+        return new FinalisedJob(projectId, fetchJobInfo);
       }
     }
-
-    public static JobModel updateJob(String projectId, Job job, Dataflow dataflowService, String lastModified) 
+    
+    // Jobs only have the metrics that were modified sincer lastUpdate different from null
+    public static JobModel updateJob(String projectId, FetchJobInfo fetchJobInfo, String lastModified) 
         throws IOException, IllegalArgumentException {
       JobModel updatedJob;
-      String state = job.getCurrentState();
+      String state = fetchJobInfo.getState();
       if (state.compareTo("JOB_STATE_UNKNOWN") == 0 
              || state.compareTo("JOB_STATE_STOPPED") == 0
              || state.compareTo("JOB_STATE_RUNNING") == 0
@@ -191,12 +118,12 @@ public abstract class JobModel {
              || state.compareTo("JOB_STATE_PENDING") == 0
              || state.compareTo("JOB_STATE_CANCELLING") == 0
              || state.compareTo("JOB_STATE_QUEUED") == 0) {
-        updatedJob =  new RunningJob(projectId, job.getId(), job.getCurrentState(), job.getCurrentStateTime(), job.getLocation());
+        updatedJob =  new RunningJob(projectId, fetchJobInfo.getId(), fetchJobInfo.getState(), fetchJobInfo.getStateTime(), fetchJobInfo.getRegion());
       } else {
-        updatedJob = new FinalisedJob(projectId, job.getId(), job.getCurrentState(), job.getCurrentStateTime(), job.getLocation());
+        updatedJob = new FinalisedJob(projectId, fetchJobInfo.getId(), fetchJobInfo.getState(), fetchJobInfo.getStateTime(), fetchJobInfo.getRegion());
       }
 
-      updatedJob.getMetrics(dataflowService, lastModified);
+      fetchJobInfo.setMetrics(updatedJob, lastModified);
 
       return updatedJob;
     }

--- a/src/main/java/com/google/sps/data/RunningJob.java
+++ b/src/main/java/com/google/sps/data/RunningJob.java
@@ -24,11 +24,11 @@ import java.lang.IllegalArgumentException;
 // - JOB_STATE_CANCELLING
 // - JOB_STATE_QUEUED
 public final class RunningJob extends JobModel {
-    public RunningJob(String projectId, Job job, Dataflow dataflowService) throws IOException, IllegalArgumentException {
-        super(projectId, job, dataflowService);
+    public RunningJob(String projectId, FetchJobInfo fetchJobInfo) throws IOException, IllegalArgumentException {
+        super(projectId, fetchJobInfo);
 
-        state = job.getCurrentState();
-        stateTime = job.getCurrentStateTime();
+        state = fetchJobInfo.getState();
+        stateTime = fetchJobInfo.getStateTime();
     }
 
     public RunningJob(String projectId, String id, String state, String stateTime, String region) throws IOException, IllegalArgumentException {


### PR DESCRIPTION
1. Add interface FetchJobInfo that has all the methods needed to fetch a job. This interface would help in creating mock objects for testing
2. Add class FetchJobFromServer that would implement FetchJobInfo and would consist in the actual methods that would fetch a job from the Dataflow server
3. Modified JobModel, RunningJob and FinalisedJob to be compatible with the interface FetchJobInfo