### PR TITLE
Add unit test for JobStoreCenter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,11 +41,6 @@
       <version>2.8.6</version>
     </dependency>
     <dependency>
-      <groupId>com.google.appengine</groupId>
-      <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>1.9.59</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
       <version>1.30.4</version>
@@ -95,6 +90,35 @@
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
       <version>20200518</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-testing</artifactId>
+      <version>1.9.59</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-labs</artifactId>
+      <version>1.9.59</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-stubs</artifactId>
+      <version>1.9.59</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-tools-sdk</artifactId>
+      <version>1.9.59</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/com/google/sps/ProjectLoaderStub.java
+++ b/src/main/java/com/google/sps/ProjectLoaderStub.java
@@ -22,7 +22,7 @@ public class ProjectLoaderStub implements ProjectLoader {
 
   // Jobs that are used to tell which fields have been modified or not
   // They shoud be jobs with the same jobId as the jobs found in updatedJobs
-  private List<JobJSON> updateHelpersJobs = null;
+  private Map<JobJSON, Boolean> updateHelpersJobs = null;
   // Updated Jobs. All jobs included in this list should have one associated helper
   // found in updateHelpersJobs
   private List<JobJSON> updatedJobs = null;
@@ -88,7 +88,7 @@ public class ProjectLoaderStub implements ProjectLoader {
     return null; 
   }
 
-  public void setUpdate(List<JobJSON> updateHelpersJobs, List<JobJSON> updatedJobs) {
+  public void setUpdate(Map<JobJSON, Boolean> updateHelpersJobs, List<JobJSON> updatedJobs) {
     this.updateHelpersJobs = updateHelpersJobs;
     this.updatedJobs = updatedJobs;
 
@@ -105,9 +105,9 @@ public class ProjectLoaderStub implements ProjectLoader {
     }
 
     List<JobModel> jobs = new ArrayList<>();
-    fetchJobs.setIfUpdated(true);
 
-    for (JobJSON job : updateHelpersJobs) {
+    for (JobJSON job : updateHelpersJobs.keySet()) {
+      fetchJobs.setIfUpdated(updateHelpersJobs.get(job));
       fetchJobs.setJob(job);
       jobs.add(JobModel.createJob(projectId, fetchJobs));  
     }

--- a/src/main/java/com/google/sps/ProjectLoaderStub.java
+++ b/src/main/java/com/google/sps/ProjectLoaderStub.java
@@ -18,30 +18,46 @@ import java.util.HashMap;
 
 public class ProjectLoaderStub implements ProjectLoader {
   private Map<String, List<JobJSON>> mapOfJobs;
-  private List<JobJSON> allJobs;
-  private List<JobJSON> allUpdatedJobs;
+  private Map<String, JobJSON> allJobs;
+
+  // Jobs that are used to tell which fields have been modified or not
+  // They shoud be jobs with the same jobId as the jobs found in updatedJobs
+  private List<JobJSON> updateHelpersJobs = null;
+  // Updated Jobs. All jobs included in this list should have one associated helper
+  // found in updateHelpersJobs
+  private List<JobJSON> updatedJobs = null;
+
   private String projectId;
   private FetchJobStub fetchJobs = new FetchJobStub();
 
-  public ProjectLoaderStub(Map<String, List<JobJSON>> mapOfJobs, String projectId, 
-                           List<JobJSON> allJobs, List<JobJSON> allUpdatedJobs) {
+  public ProjectLoaderStub(Map<String, List<JobJSON>> mapOfJobs, String projectId) {
+    this(projectId);
+
     this.mapOfJobs = mapOfJobs;
     this.projectId = projectId;
-    this.allJobs = allJobs;
-    this.allUpdatedJobs = allUpdatedJobs;
+
+    Iterator<String> it = this.mapOfJobs.keySet().iterator();
+
+    while (it.hasNext()) {
+      String region = it.next();
+      for (JobJSON job : mapOfJobs.get(region)) {
+        allJobs.put(job.id, job);
+      }
+    }
   }
 
   public ProjectLoaderStub(String projectId) {
-    mapOfJobs = new HashMap<>();
     this.projectId = projectId;
-    allJobs = new ArrayList<>();
-    allUpdatedJobs = new ArrayList<>();
+    allJobs = new HashMap<>();
+    mapOfJobs = new HashMap<>();
   }
 
   public List<JobModel> fetchJobs() throws IOException {
     List<JobModel> jobs = new ArrayList<>();
 
-    for (JobJSON job : allJobs) {
+    for (String id : allJobs.keySet()) {
+      JobJSON job = allJobs.get(id);
+      
       fetchJobs.setJob(job);
       jobs.add(JobModel.createJob(projectId, fetchJobs)); 
     }
@@ -50,17 +66,10 @@ public class ProjectLoaderStub implements ProjectLoader {
   }
   // Fetch a job from a project, based on the jobId
   public JobModel fetch(String jobId) throws IOException {
-    Iterator<String> it = mapOfJobs.keySet().iterator();
-
-    while (it.hasNext()) {
-      String region = it.next();
-
-      for (JobJSON job : mapOfJobs.get(region)) {
-        if (jobId.compareTo(job.id) == 0) {
-          fetchJobs.setJob(job);
-          return JobModel.createJob(projectId, fetchJobs); 
-        } 
-      }
+    if (allJobs.containsKey(jobId)) {
+      JobJSON job = allJobs.get(jobId);
+      fetchJobs.setJob(job);
+      return JobModel.createJob(projectId, fetchJobs);
     }
 
     return null;  
@@ -68,30 +77,42 @@ public class ProjectLoaderStub implements ProjectLoader {
 
   //Fetch a job from a project based on the job Id and its location
   public JobModel fetch(String jobId, String location) throws IOException {
-    if (mapOfJobs.containsKey(location)) {
-      for (JobJSON job : mapOfJobs.get(location)) {
-        if (jobId.compareTo(job.id) == 0) {
-          fetchJobs.setJob(job);
-          return JobModel.createJob(projectId, fetchJobs); 
-        } 
-      } 
+    if (allJobs.containsKey(jobId)) {
+      JobJSON job = allJobs.get(jobId);
+      if (job.region.compareTo(location) == 0) {
+        fetchJobs.setJob(job);
+        return JobModel.createJob(projectId, fetchJobs);
+      }
     }
 
     return null; 
   }
 
-  public void setUpdatedJobs(List<JobJSON> allUpdatedJobs) {
-    this.allUpdatedJobs = allUpdatedJobs;
+  public void setUpdate(List<JobJSON> updateHelpersJobs, List<JobJSON> updatedJobs) {
+    this.updateHelpersJobs = updateHelpersJobs;
+    this.updatedJobs = updatedJobs;
+
+    for (JobJSON job : updatedJobs) {
+      allJobs.replace(job.id, job);
+    }
   }
 
   // Jobs have the metrics that were modified since lastUpdate different from null
   public List<JobModel> fetchJobsforUpdate(String lastUpdate) throws IOException {
-    List<JobModel> jobs = new ArrayList<>();
 
-    for (JobJSON job : allUpdatedJobs) {
+    if (updateHelpersJobs == null) {
+      return new ArrayList<JobModel>();
+    }
+
+    List<JobModel> jobs = new ArrayList<>();
+    fetchJobs.setIfUpdated(true);
+
+    for (JobJSON job : updateHelpersJobs) {
       fetchJobs.setJob(job);
       jobs.add(JobModel.createJob(projectId, fetchJobs));  
     }
+
+    fetchJobs.setIfUpdated(false);
 
     return jobs;
   }

--- a/src/test/java/com/google/sps/JobStoreCenterTest.java
+++ b/src/test/java/com/google/sps/JobStoreCenterTest.java
@@ -73,6 +73,10 @@ public final class JobStoreCenterTest {
                                                      "europe-west2", 0, null, 100.0, 101.0, 102.0, 
                                                             103.0, 4, 105.0, true, TIME1, "JOB_STATE_CANCELLED", TIME1, null, "Apache Beam SDK for Java",
                                                                 201.0, 202.0, 203.0);
+  private static final JobJSON JOB2_NO_UPDATE = new JobJSON(PROJECT1, null, "job2", null, null, null,
+                                                     "europe-west2", 0, null, null, null, null, 
+                                                            null, null, null, null, null, "JOB_STATE_CANCELLED", TIME1, null, null,
+                                                                null, null, null);
 
   @BeforeClass
   public static void initialiseVariables() {
@@ -222,7 +226,9 @@ public final class JobStoreCenterTest {
     jobStoreCenter.dealWithProject(PROJECT1, projectLoader);
     
     // Update the project in the server
-    projectLoader.setUpdate(Arrays.asList(JOB1_UPDATED_RUNNING), Arrays.asList(JOB1_RUNNING_AFTER_UPDATE));
+    Map<JobJSON, Boolean> updateHelpersJobs = new HashMap<>();
+    updateHelpersJobs.put(JOB1_UPDATED_RUNNING, true);
+    projectLoader.setUpdate(updateHelpersJobs, Arrays.asList(JOB1_RUNNING_AFTER_UPDATE));
 
     clock.setTime(TIME4);
     jobStoreCenter.dealWithProject(PROJECT1, projectLoader);
@@ -256,7 +262,9 @@ public final class JobStoreCenterTest {
     jobStoreCenter.dealWithProject(PROJECT1, projectLoader);
     
     // Make the update at the server
-    projectLoader.setUpdate(Arrays.asList(JOB1_UPDATED_FINALISED), Arrays.asList(JOB1_FINALISED_AFTER_UPDATE));
+    Map<JobJSON, Boolean> updateHelpersJobs = new HashMap<>();
+    updateHelpersJobs.put(JOB1_UPDATED_FINALISED, true);
+    projectLoader.setUpdate(updateHelpersJobs, Arrays.asList(JOB1_FINALISED_AFTER_UPDATE));
 
     clock.setTime(TIME4);
     jobStoreCenter.dealWithProject(PROJECT1, projectLoader);
@@ -292,7 +300,10 @@ public final class JobStoreCenterTest {
     jobStoreCenter.dealWithProject(PROJECT1, projectLoader);
     
     // Update the project in the server
-    projectLoader.setUpdate(Arrays.asList(JOB1_UPDATED_RUNNING), Arrays.asList(JOB1_RUNNING_AFTER_UPDATE));
+    Map<JobJSON, Boolean> updateHelpersJobs = new HashMap<>();
+    updateHelpersJobs.put(JOB1_UPDATED_RUNNING, true);
+    updateHelpersJobs.put(JOB2_NO_UPDATE, false);
+    projectLoader.setUpdate(updateHelpersJobs, Arrays.asList(JOB1_RUNNING_AFTER_UPDATE));
 
     clock.setTime(TIME4);
     jobStoreCenter.dealWithProject(PROJECT1, projectLoader);

--- a/src/test/java/com/google/sps/JobStoreCenterTest.java
+++ b/src/test/java/com/google/sps/JobStoreCenterTest.java
@@ -197,7 +197,6 @@ public final class JobStoreCenterTest {
     clock.setTime(TIME2);
     jobStoreCenter.dealWithProject(PROJECT1, projectLoader);
     
-    // Datastore should contain only 2 elements
     int expectedNumberOfObjects = 3;
     int actualNumberOfObjects = datastore.prepare(new Query()).countEntities();
     Assert.assertEquals(expectedNumberOfObjects, actualNumberOfObjects);

--- a/src/test/java/com/google/sps/JobStoreCenterTest.java
+++ b/src/test/java/com/google/sps/JobStoreCenterTest.java
@@ -1,0 +1,321 @@
+// Copyright 2020 Google LLC
+
+/**
+ * @author andreeanica
+ */
+
+package com.google.sps;
+
+import org.junit.Ignore;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import java.io.IOException;
+import com.google.sps.data.JobJSON;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Arrays;
+import java.util.ArrayList;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Query;
+import static com.google.appengine.api.datastore.FetchOptions.Builder.withLimit;
+import com.google.appengine.api.datastore.EntityNotFoundException;
+
+@RunWith(JUnit4.class)
+public final class JobStoreCenterTest {
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+
+  private static JobStoreCenter jobStoreCenter;
+  private static DatastoreService datastore;
+  private static ClockStub clock;
+
+  private static final String TIME1 = "2007-12-03T10:15:30.00Z";
+  private static final String TIME2 = "2008-12-03T10:15:30.00Z";
+  private static final String TIME3 = "2009-12-03T10:15:30.00Z";
+  private static final String TIME4 = "2019-12-03T10:15:30.00Z";
+
+  private static final String PROJECT1 = "project1";
+  private static final JobJSON JOB1 = new JobJSON(PROJECT1, "job1", "job1", "JOB_TYPE_STREAMING", "2.23.0", "SUPPORTED",
+                                                     "europe-west1", 0, TIME1, 100.0, 101.0, 102.0, 
+                                                            103.0, 4, 105.0, true, TIME1, "JOB_STATE_RUNNING", TIME1, null, "Apache Beam SDK for Java",
+                                                                201.0, 202.0, 203.0);
+  private static final JobJSON JOB1_UPDATED_RUNNING = new JobJSON(PROJECT1, null, "job1", null, null, null,
+                                                     "europe-west1", 0, null, 300.0, null, null, 
+                                                            303.0, null, null, null, TIME3, "JOB_STATE_RUNNING", TIME1, null, null,
+                                                                301.0, null, null);
+  private static final JobJSON JOB1_RUNNING_AFTER_UPDATE = new JobJSON(PROJECT1, "job1", "job1", "JOB_TYPE_STREAMING", "2.23.0", "SUPPORTED",
+                                                     "europe-west1", 0, TIME1, 300.0, 101.0, 102.0, 
+                                                            303.0, 4, 105.0, true, TIME3, "JOB_STATE_RUNNING", TIME1, null, "Apache Beam SDK for Java",
+                                                                301.0, 202.0, 203.0);
+  private static final JobJSON JOB1_UPDATED_FINALISED = new JobJSON(PROJECT1, null, "job1", null, null, null,
+                                                     "europe-west1", 0, null, 300.0, null, null, 
+                                                            303.0, null, null, null, TIME3, "JOB_STATE_DONE", TIME3, null, null,
+                                                                301.0, null, null);
+  private static final JobJSON JOB1_FINALISED_AFTER_UPDATE = new JobJSON(PROJECT1, "job1", "job1", "JOB_TYPE_STREAMING", "2.23.0", "SUPPORTED",
+                                                     "europe-west1", 0, TIME1, 300.0, 101.0, 102.0, 
+                                                            303.0, 4, 105.0, true, TIME3, "JOB_STATE_DONE", TIME3, null, "Apache Beam SDK for Java",
+                                                                301.0, 202.0, 203.0);
+                    
+  private static final JobJSON JOB2 = new JobJSON(PROJECT1, "job2", "job2", "JOB_TYPE_STREAMING", "2.23.0", "SUPPORTED",
+                                                     "europe-west2", 0, null, 100.0, 101.0, 102.0, 
+                                                            103.0, 4, 105.0, true, TIME1, "JOB_STATE_CANCELLED", TIME1, null, "Apache Beam SDK for Java",
+                                                                201.0, 202.0, 203.0);
+
+  @BeforeClass
+  public static void initialiseVariables() {
+    // Initialize the constants that would be used for testing
+
+    PriceCenter priceCenter = new PriceCenter();
+    JOB1_RUNNING_AFTER_UPDATE.price = priceCenter.calculatePrice(JOB1_RUNNING_AFTER_UPDATE);
+    JOB1_FINALISED_AFTER_UPDATE.price = priceCenter.calculatePrice(JOB1_FINALISED_AFTER_UPDATE);
+    JOB2.price = priceCenter.calculatePrice(JOB2);
+  }
+  
+  @Before
+  public void setUp() {
+    helper.setUp();
+    clock = new ClockStub();
+    jobStoreCenter = new JobStoreCenter(clock);
+
+    datastore = DatastoreServiceFactory.getDatastoreService(); 
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown() ;
+  }
+
+  @Test
+  public void emptyProject() throws EntityNotFoundException, IOException {
+    // Add only an empty project to the Database
+    ProjectLoader projectLoader = new ProjectLoaderStub(PROJECT1); 
+    clock.setTime(TIME1);
+    jobStoreCenter.dealWithProject(PROJECT1, projectLoader);
+    
+    int expectedNumberOfObjects = 1;
+    int actualNumberOfObjects = datastore.prepare(new Query()).countEntities(withLimit(10));
+    Assert.assertEquals(expectedNumberOfObjects, actualNumberOfObjects);
+    
+    Key projectKey = KeyFactory.createKey("Project", PROJECT1);
+    Entity actualProject = datastore.get(projectKey);
+
+    Assert.assertEquals(TIME1, actualProject.getProperty("lastAccessed"));
+  }
+
+  public void addTwiceTheSameProject() throws EntityNotFoundException, IOException {
+    // Add the same project twice. The Datastore should contain only one project
+    ProjectLoader projectLoader = new ProjectLoaderStub(PROJECT1); 
+    clock.setTime(TIME1);
+    jobStoreCenter.dealWithProject(PROJECT1, projectLoader);
+
+    clock.setTime(TIME2);
+    jobStoreCenter.dealWithProject(PROJECT1, projectLoader);
+    
+    int expectedNumberOfObjects = 1;
+    int actualNumberOfObjects = datastore.prepare(new Query()).countEntities(withLimit(10));
+    Assert.assertEquals(expectedNumberOfObjects, actualNumberOfObjects);
+    
+    Key projectKey = KeyFactory.createKey("Project", PROJECT1);
+    Entity actualProject = datastore.get(projectKey);
+
+    Assert.assertEquals(TIME2, actualProject.getProperty("lastAccessed"));
+  }
+
+  @Test
+  public void addProjectWithRunningJob() throws IOException, EntityNotFoundException {
+    // Add a project that has only one job (the job is running)
+    Map<String, List<JobJSON>> mapOfJobs = new HashMap<>();
+    mapOfJobs.put("europe-west1", Arrays.asList(JOB1));
+
+    ProjectLoader projectLoader = new ProjectLoaderStub(mapOfJobs, PROJECT1);
+    clock.setTime(TIME2);
+    jobStoreCenter.dealWithProject(PROJECT1, projectLoader);
+    
+    // Datastore should contain only 2 elements
+    int expectedNumberOfObjects = 2;
+    int actualNumberOfObjects = datastore.prepare(new Query()).countEntities();
+    Assert.assertEquals(expectedNumberOfObjects, actualNumberOfObjects);
+
+    int expectedNumberOfProjects = 1;
+    int actualNumberOfProjects = datastore.prepare(new Query("Project")).countEntities();
+    Assert.assertEquals(expectedNumberOfProjects, actualNumberOfProjects);
+
+    int expectedNumberOfJobs = 1;
+    int actualNumberOfJobs = datastore.prepare(new Query("RunningJob")).countEntities();
+    Assert.assertEquals(expectedNumberOfJobs, actualNumberOfJobs);
+  }
+
+  @Test
+  public void addProjectWithFinalisedJob() throws IOException, EntityNotFoundException {
+    // Add a project that has only one job (the job is finalised)
+    Map<String, List<JobJSON>> mapOfJobs = new HashMap<>();
+    mapOfJobs.put("europe-west2", Arrays.asList(JOB2));
+
+    ProjectLoader projectLoader = new ProjectLoaderStub(mapOfJobs, PROJECT1);
+    clock.setTime(TIME2);
+    jobStoreCenter.dealWithProject(PROJECT1, projectLoader);
+    
+    // Datastore should contain only 2 elements
+    int expectedNumberOfObjects = 2;
+    int actualNumberOfObjects = datastore.prepare(new Query()).countEntities();
+    Assert.assertEquals(expectedNumberOfObjects, actualNumberOfObjects);
+
+    int expectedNumberOfProjects = 1;
+    int actualNumberOfProjects = datastore.prepare(new Query("Project")).countEntities();
+    Assert.assertEquals(expectedNumberOfProjects, actualNumberOfProjects);
+
+    int expectedNumberOfJobs = 1;
+    int actualNumberOfJobs = datastore.prepare(new Query("FinalisedJob")).countEntities();
+    Assert.assertEquals(expectedNumberOfJobs, actualNumberOfJobs);
+  }
+
+  @Test
+  public void addJobWithBothTypesOfJobs() throws IOException, EntityNotFoundException {
+    // Add a project that has only one job (the job is finalised)
+    Map<String, List<JobJSON>> mapOfJobs = new HashMap<>();
+    mapOfJobs.put("europe-west1", Arrays.asList(JOB1));
+    mapOfJobs.put("europe-west2", Arrays.asList(JOB2));
+
+    ProjectLoader projectLoader = new ProjectLoaderStub(mapOfJobs, PROJECT1);
+    clock.setTime(TIME2);
+    jobStoreCenter.dealWithProject(PROJECT1, projectLoader);
+    
+    // Datastore should contain only 2 elements
+    int expectedNumberOfObjects = 3;
+    int actualNumberOfObjects = datastore.prepare(new Query()).countEntities();
+    Assert.assertEquals(expectedNumberOfObjects, actualNumberOfObjects);
+
+    int expectedNumberOfProjects = 1;
+    int actualNumberOfProjects = datastore.prepare(new Query("Project")).countEntities();
+    Assert.assertEquals(expectedNumberOfProjects, actualNumberOfProjects);
+
+    int expectedNumberOfJobs = 1;
+    int actualNumberOfJobs = datastore.prepare(new Query("FinalisedJob")).countEntities();
+    Assert.assertEquals(expectedNumberOfJobs, actualNumberOfJobs);
+
+    int expectedNumberOfRunningJobs = 1;
+    int actualNumberOfRunningJobs = datastore.prepare(new Query("RunningJob")).countEntities();
+    Assert.assertEquals(expectedNumberOfRunningJobs, actualNumberOfRunningJobs);
+  }
+
+  @Test
+  public void updateProject() throws IOException, EntityNotFoundException {
+    // Add a project that has a job. Than update that job. The job is still running, after the update
+    Map<String, List<JobJSON>> mapOfJobs = new HashMap<>();
+    mapOfJobs.put("europe-west1", Arrays.asList(JOB1));
+
+    ProjectLoaderStub projectLoader = new ProjectLoaderStub(mapOfJobs, PROJECT1);
+    clock.setTime(TIME2);
+    jobStoreCenter.dealWithProject(PROJECT1, projectLoader);
+    
+    // Update the project in the server
+    projectLoader.setUpdate(Arrays.asList(JOB1_UPDATED_RUNNING), Arrays.asList(JOB1_RUNNING_AFTER_UPDATE));
+
+    clock.setTime(TIME4);
+    jobStoreCenter.dealWithProject(PROJECT1, projectLoader);
+    
+    int expectedNumberOfObjects = 2;
+    int actualNumberOfObjects = datastore.prepare(new Query()).countEntities();
+    Assert.assertEquals(expectedNumberOfObjects, actualNumberOfObjects);
+
+    int expectedNumberOfProjects = 1;
+    int actualNumberOfProjects = datastore.prepare(new Query("Project")).countEntities();
+    Assert.assertEquals(expectedNumberOfProjects, actualNumberOfProjects);
+
+    int expectedNumberOfJobs = 1;
+    int actualNumberOfJobs = datastore.prepare(new Query("RunningJob")).countEntities();
+    Assert.assertEquals(expectedNumberOfJobs, actualNumberOfJobs);
+
+    List<JobJSON> expectedList =  Arrays.asList(JOB1_RUNNING_AFTER_UPDATE);
+    List<JobJSON> actualList = jobStoreCenter.getJobsFromDatastore(PROJECT1);
+    Assert.assertEquals(expectedList, actualList);
+  }
+
+  @Test
+  public void updatedJobFromRunningToFinalised() throws IOException{
+    // Add a project that has a job. Than update that job. The job is finalised, so 
+    // it should be updated from RunningJob to FinalisedJob 
+    Map<String, List<JobJSON>> mapOfJobs = new HashMap<>();
+    mapOfJobs.put("europe-west1", Arrays.asList(JOB1));
+
+    ProjectLoaderStub projectLoader = new ProjectLoaderStub(mapOfJobs, PROJECT1);
+    clock.setTime(TIME2);
+    jobStoreCenter.dealWithProject(PROJECT1, projectLoader);
+    
+    // Make the update at the server
+    projectLoader.setUpdate(Arrays.asList(JOB1_UPDATED_FINALISED), Arrays.asList(JOB1_FINALISED_AFTER_UPDATE));
+
+    clock.setTime(TIME4);
+    jobStoreCenter.dealWithProject(PROJECT1, projectLoader);
+    
+    int expectedNumberOfObjects = 2;
+    int actualNumberOfObjects = datastore.prepare(new Query()).countEntities();
+    Assert.assertEquals(expectedNumberOfObjects, actualNumberOfObjects);
+
+    int expectedNumberOfProjects = 1;
+    int actualNumberOfProjects = datastore.prepare(new Query("Project")).countEntities();
+    Assert.assertEquals(expectedNumberOfProjects, actualNumberOfProjects);
+
+    int expectedNumberOfJobs = 1;
+    int actualNumberOfJobs = datastore.prepare(new Query("FinalisedJob")).countEntities();
+    Assert.assertEquals(expectedNumberOfJobs, actualNumberOfJobs);
+
+    List<JobJSON> expectedList =  Arrays.asList(JOB1_FINALISED_AFTER_UPDATE);
+    List<JobJSON> actualList = jobStoreCenter.getJobsFromDatastore(PROJECT1);
+    Assert.assertEquals(expectedList, actualList); 
+  }
+
+  @Test
+  public void updateProjectWith2Jobs() throws IOException {
+    // Add a project that has both a running job and a finalised one. 
+    // Update the running job. The finalised one should not be modified
+
+    Map<String, List<JobJSON>> mapOfJobs = new HashMap<>();
+    mapOfJobs.put("europe-west1", Arrays.asList(JOB1));
+    mapOfJobs.put("europe-west2", Arrays.asList(JOB2));
+
+    ProjectLoaderStub projectLoader = new ProjectLoaderStub(mapOfJobs, PROJECT1);
+    clock.setTime(TIME2);
+    jobStoreCenter.dealWithProject(PROJECT1, projectLoader);
+    
+    // Update the project in the server
+    projectLoader.setUpdate(Arrays.asList(JOB1_UPDATED_RUNNING), Arrays.asList(JOB1_RUNNING_AFTER_UPDATE));
+
+    clock.setTime(TIME4);
+    jobStoreCenter.dealWithProject(PROJECT1, projectLoader);
+    
+    int expectedNumberOfObjects = 3;
+    int actualNumberOfObjects = datastore.prepare(new Query()).countEntities();
+    Assert.assertEquals(expectedNumberOfObjects, actualNumberOfObjects);
+
+    int expectedNumberOfProjects = 1;
+    int actualNumberOfProjects = datastore.prepare(new Query("Project")).countEntities();
+    Assert.assertEquals(expectedNumberOfProjects, actualNumberOfProjects);
+
+    int expectedNumberOfRunningJobs = 1;
+    int actualNumberOfRunningJobs = datastore.prepare(new Query("RunningJob")).countEntities();
+    Assert.assertEquals(expectedNumberOfRunningJobs, actualNumberOfRunningJobs);
+
+    int expectedNumberOfFinalisedJobs = 1;
+    int actualNumberOfFinalisedJobs = datastore.prepare(new Query("FinalisedJob")).countEntities();
+    Assert.assertEquals(expectedNumberOfFinalisedJobs, actualNumberOfFinalisedJobs);
+
+    List<JobJSON> expectedList =  Arrays.asList(JOB2, JOB1_RUNNING_AFTER_UPDATE);
+    List<JobJSON> actualList = jobStoreCenter.getJobsFromDatastore(PROJECT1);
+    Assert.assertEquals(expectedList, actualList);
+  }
+}
+    


### PR DESCRIPTION
1. Modify pom.xml to include all the needed dependencies
2. Modify how the ProjectLoaderStub class deals with an update. The update is added by calling the method setUpdate, that takes 2 parameters: the first parameter is a list with jobs, and only the fields that have been modified since our last call would have a value different from null. The other parameter is the list with the job in its current form, after being modified. These jobs would replace the initial ones, and so the ProjectLoaderStub would return the updated version of the job when fetching the job again.
3. Added unit test for JobStoreCenter that tests storing the information correctly to Datastore