### PR TITLE
Solve some errors that were causing exceptions

### DIFF
--- a/src/main/java/com/google/sps/JobStoreCenter.java
+++ b/src/main/java/com/google/sps/JobStoreCenter.java
@@ -135,8 +135,10 @@ public final class JobStoreCenter {
     Double totalMemoryTime = (Double) entity.getProperty("totalMemoryTime"); 
     Double totalDiskTimeHDD = (Double) entity.getProperty("totalDiskTimeHDD");
     Double totalDiskTimeSSD = (Double) entity.getProperty("totalDiskTimeSSD");
-    Long longCurrentVcpuCount = (Long) entity.getProperty("currentVcpuCount");
-    Integer currentVcpuCount = longCurrentVcpuCount == null? null : longCurrentVcpuCount.intValue();
+    Integer currentVcpuCount = null;
+    if (entity.getProperty("currentVcpuCount") != null) {
+      currentVcpuCount = new Integer(entity.getProperty("currentVcpuCount").toString());
+    }
     Double totalStreamingData = (Double) entity.getProperty("totalStreamingData"); 
     Boolean enableStreamingEngine = (Boolean) entity.getProperty("enableStreamingEngine");
     Double currentMemoryUsage = (Double) entity.getProperty("currentMemoryUsage");

--- a/src/main/java/com/google/sps/data/FinalisedJob.java
+++ b/src/main/java/com/google/sps/data/FinalisedJob.java
@@ -28,8 +28,8 @@ public final class FinalisedJob extends JobModel {
         stateTime = fetchJobInfo.getStateTime();
     }
 
-    public FinalisedJob(String projectId, String id, String state, String stateTime, String region) throws IOException, IllegalArgumentException {
-      super(projectId, id, region);
+    public FinalisedJob(String projectId, String id, String state, String stateTime, String region, String type) throws IOException, IllegalArgumentException {
+      super(projectId, id, region, type);
 
       this.state = state;
       this.stateTime = stateTime;

--- a/src/main/java/com/google/sps/data/JobModel.java
+++ b/src/main/java/com/google/sps/data/JobModel.java
@@ -63,13 +63,13 @@ public abstract class JobModel {
     public String state;
     public String stateTime;
 
-    public JobModel(String projectId, String id, String region) {
+    public JobModel(String projectId, String id, String region, String type) {
       this.projectId = projectId;
       this.id = id;
       this.region = region;
+      this.type = type;
 
       name = null;
-      type = null;
       sdkName = null;
       startTime = null;
       enableStreamingEngine = null;
@@ -118,9 +118,11 @@ public abstract class JobModel {
              || state.compareTo("JOB_STATE_PENDING") == 0
              || state.compareTo("JOB_STATE_CANCELLING") == 0
              || state.compareTo("JOB_STATE_QUEUED") == 0) {
-        updatedJob =  new RunningJob(projectId, fetchJobInfo.getId(), fetchJobInfo.getState(), fetchJobInfo.getStateTime(), fetchJobInfo.getRegion());
+        updatedJob =  new RunningJob(projectId, fetchJobInfo.getId(), fetchJobInfo.getState(), 
+                          fetchJobInfo.getStateTime(), fetchJobInfo.getRegion(), fetchJobInfo.getType());
       } else {
-        updatedJob = new FinalisedJob(projectId, fetchJobInfo.getId(), fetchJobInfo.getState(), fetchJobInfo.getStateTime(), fetchJobInfo.getRegion());
+        updatedJob = new FinalisedJob(projectId, fetchJobInfo.getId(), fetchJobInfo.getState(),
+                          fetchJobInfo.getStateTime(), fetchJobInfo.getRegion(), fetchJobInfo.getType());
       }
 
       fetchJobInfo.setMetrics(updatedJob, lastModified);

--- a/src/main/java/com/google/sps/data/RunningJob.java
+++ b/src/main/java/com/google/sps/data/RunningJob.java
@@ -31,8 +31,8 @@ public final class RunningJob extends JobModel {
         stateTime = fetchJobInfo.getStateTime();
     }
 
-    public RunningJob(String projectId, String id, String state, String stateTime, String region) throws IOException, IllegalArgumentException {
-      super(projectId, id, region);
+    public RunningJob(String projectId, String id, String state, String stateTime, String region, String type) throws IOException, IllegalArgumentException {
+      super(projectId, id, region, type);
 
       this.state = state;
       this.stateTime = stateTime;

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -13,7 +13,7 @@ function initBody() {
   google.charts.load('current', {'packages':['corechart']});
   google.charts.load('current', {
         'packages':['geochart'],
-        'mapsApiKey': config.mapApiKey,
+        'mapsApiKey': credentials.mapApiKey,
       });
 }
 


### PR DESCRIPTION
1. Solve in PriceCenter the error coused by the updated jobs. An updated job should also keep track of its type, to be able to calculate the price
2. Solve an error that was causing an exception when casting a long to an int.