### PR TITLE
Handle wrong access credentials

### DIFF
--- a/src/main/java/com/google/sps/servlets/SetCredentialsServlet.java
+++ b/src/main/java/com/google/sps/servlets/SetCredentialsServlet.java
@@ -7,6 +7,7 @@
 package com.google.sps.servlets;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 
 import java.lang.Exception;
@@ -47,24 +48,33 @@ public class SetCredentialsServlet extends HttpServlet {
     String bucketName = request.getParameter("bucket");
     String objectName = request.getParameter("object");
     String projectId = request.getParameter("projID");
-   
-    Storage storage = StorageOptions.newBuilder()
-                .setProjectId(projectId)
-                .setCredentials(GoogleCredentials.getApplicationDefault())
-                .build()
-                .getService();
 
-    Blob blob = storage.get(bucketName, objectName);
-    String fileContent = new String(blob.getContent());
+    Boolean getCredentials = false;
+    Gson gson = new Gson();
+    response.setContentType("application/json;");
 
-    File file = new File("pom.xml");
-    String outputPath = file.getAbsoluteFile().getParent() + "/" + projectId + ".json";
+    try{
+      Storage storage = StorageOptions.newBuilder()
+                  .setProjectId(projectId)
+                  .setCredentials(GoogleCredentials.getApplicationDefault())
+                  .build()
+                  .getService();
 
-    PrintWriter out = new PrintWriter(new FileWriter(outputPath));
-    out.println(fileContent);
-    out.flush();
-    out.close();
+      Blob blob = storage.get(bucketName, objectName);
+      String fileContent = new String(blob.getContent());
 
-    response.sendRedirect("/");
+      File file = new File("pom.xml");
+      String outputPath = file.getAbsoluteFile().getParent() + "/" + projectId + ".json";
+
+      PrintWriter out = new PrintWriter(new FileWriter(outputPath));
+      out.println(fileContent);
+      out.flush();
+      out.close();
+      
+      getCredentials = true;
+      response.getWriter().println(gson.toJson(getCredentials));
+    } catch (Exception e) {
+      response.getWriter().println(gson.toJson(getCredentials));
+    }
   }
 }

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -9,7 +9,6 @@ var sdkVisited = false;
 
 function initBody() {
   document.getElementById('projectID').value = config.projectID;
-  setCredentialsServlet();
   google.charts.load('current', {'packages':['corechart']});
   google.charts.load('current', {
         'packages':['geochart'],
@@ -19,8 +18,17 @@ function initBody() {
 
 function setCredentialsServlet() {
   var credentialsUrl = formatURLs('get-credentials', {'projID':config.projectID, 'bucket':config.bucketName, 'object':config.objectName});
-  fetch(credentialsUrl)
-  .then(response => checkPermissions());
+  let ana = fetch(credentialsUrl)
+  .then(response => response.json())
+  .then(worked => {
+    if (worked) {
+      checkPermissions();
+      makeFormDisappear();
+      initBody();
+    } else {
+      document.getElementById('accessForm').style.backgroundColor = 'rgb(243, 198, 198)';
+    }
+  });
 }
 
 function checkPermissions() {
@@ -98,13 +106,11 @@ function accessFunction() {
     return;
   }
 
-  makeFormDisappear();
-  
   config.projectID = projectId;
   config.bucketName = bucketName;
   config.objectName = objectName;
 
-  initBody();
+  setCredentialsServlet();
 }
 
 function updateProjectDatabase() {


### PR DESCRIPTION
If the projectId, bucketName or objectName are set incorrectly, then the user has to re-enter this information in order to access the main page.