### PR TITLE
Fix error caused when agregating jobs with null fields

### DIFF
--- a/src/main/java/com/google/sps/AggregationCenter.java
+++ b/src/main/java/com/google/sps/AggregationCenter.java
@@ -30,6 +30,10 @@ public final class AggregationCenter {
     Map<String, List<JobJSON>> groupedJobs = new HashMap<>();
 
     for (JobJSON job : jobs) {
+      if (job.name == null) {
+        continue;
+      }
+
       Matcher m = jobPattern.matcher(job.name);
 
       if (m.find()) {
@@ -62,6 +66,11 @@ public final class AggregationCenter {
 
     for (JobJSON job : jobs) {
       String key = keyGenerator.computeKey(job);
+
+      if (key == null) {
+        continue;
+      }
+      
       if (groupedJobs.containsKey(key)) {
         groupedJobs.get(key).add(job);
       } else {
@@ -85,6 +94,10 @@ public final class AggregationCenter {
   public Map<String, List<JobJSON>> aggregateBySDK(List<JobJSON> jobs) {
     return aggregateBy(jobs, new KeyGenerator() {
       public String computeKey(JobJSON job) {
+          if (job.sdk == null && job.sdkSupportStatus == null) {
+            return null;
+          }
+
           return job.sdk + " " + job.sdkSupportStatus;
       }
     }) ;
@@ -101,7 +114,13 @@ public final class AggregationCenter {
   public Map<String, List<JobJSON>> aggregateByProgrammingLanguage(List<JobJSON> jobs) {
     return aggregateBy(jobs, new KeyGenerator() {
       public String computeKey(JobJSON job) {
+          
         String key = job.sdkName;
+
+        if (key == null) {
+          return null;
+        }
+
         if (key.contains("Java")) {
           key = "Java";
         } else if (key.contains("Python")) {

--- a/src/test/java/com/google/sps/AggregationCenterTest.java
+++ b/src/test/java/com/google/sps/AggregationCenterTest.java
@@ -36,6 +36,9 @@ public final class AggregationCenterTest {
     private static final JobJSON JOB4 = new JobJSON(null, "jobDoesn'tRespectNaming", null,
                                                         null, "2.23.0", "SUPPORTED", "europe-west2", 0, null, null, null, null, 
                                                             null, null, null, null, null, null, null, null, null, null, null, null);
+    private static final JobJSON JOB5 = new JobJSON(null, null, null,
+                                                        null, null, null, "europe-west2", 0, null, null, null, null, 
+                                                            null, null, null, null, null, null, null, null, null, null, null, null);
     
 
     @Before
@@ -88,6 +91,20 @@ public final class AggregationCenterTest {
       Map<String, List<JobJSON>> actualMap = aggregationCenter.aggregateByName(jobs);
      
       Assert.assertEquals(expectedMap, actualMap);
+    }
+
+    @Test
+    public void testNullName() {
+      // JOB5 has a null name, so it should not be included in the aggregation
+      List<JobJSON> jobs = Arrays.asList(JOB1, JOB2, JOB3, JOB4, JOB5);
+
+      Map<String, List<JobJSON>> expectedMap = new HashMap<>();
+      expectedMap.put("beamsqldemopipeline", Arrays.asList(JOB1, JOB2));
+      expectedMap.put("otherName", Arrays.asList(JOB3));
+
+      Map<String, List<JobJSON>> actualMap = aggregationCenter.aggregateByName(jobs);
+     
+      Assert.assertEquals(expectedMap, actualMap); 
     }
 
     @Test
@@ -207,6 +224,19 @@ public final class AggregationCenterTest {
     }
 
     @Test 
+    public void nullSDK() {
+      List<JobJSON> jobs = Arrays.asList(JOB1, JOB2, JOB3, JOB4, JOB5);
+
+      Map<String, List<JobJSON>> expectedMap = new HashMap<>();
+      expectedMap.put("2.23.0 SUPPORTED", Arrays.asList(JOB1, JOB3, JOB4));
+      expectedMap.put("2.23.0-SNAPSHOT STALE", Arrays.asList(JOB2));
+
+      Map<String, List<JobJSON>> actualMap = aggregationCenter.aggregateBySDK(jobs);
+     
+      Assert.assertEquals(expectedMap, actualMap);
+    }
+
+    @Test 
     public void oneJobOneSDKSupportStatus() {
       List<JobJSON> jobs = Arrays.asList(JOB1);
 
@@ -231,6 +261,19 @@ public final class AggregationCenterTest {
       Assert.assertEquals(expectedMap, actualMap);
     }
 
+    @Test 
+    public void nullSDKSupportStatus() {
+      List<JobJSON> jobs = Arrays.asList(JOB1, JOB2, JOB3, JOB4, JOB5);
+
+      Map<String, List<JobJSON>> expectedMap = new HashMap<>();
+      expectedMap.put("SUPPORTED", Arrays.asList(JOB1, JOB3, JOB4));
+      expectedMap.put("STALE", Arrays.asList(JOB2));
+
+      Map<String, List<JobJSON>> actualMap = aggregationCenter.aggregateBySDKSupportStatus(jobs);
+     
+      Assert.assertEquals(expectedMap, actualMap);
+    }
+
     @Test
     public void oneJobOneProgrammingLanguage() {
       List<JobJSON> jobs = Arrays.asList(JOB1);
@@ -243,5 +286,16 @@ public final class AggregationCenterTest {
       Assert.assertEquals(expectedMap, actualMap);
     }
 
+    @Test
+    public void testNullSDKName() {
+      // JOB5 has null sdk Name, so it should not be taken into consideration
+      List<JobJSON> jobs = Arrays.asList(JOB1, JOB5);
 
+      Map<String, List<JobJSON>> expectedMap = new HashMap<>();
+      expectedMap.put("Java", Arrays.asList(JOB1));
+
+      Map<String, List<JobJSON>> actualMap = aggregationCenter.aggregateByProgrammingLanguage(jobs);
+     
+      Assert.assertEquals(expectedMap, actualMap);
+    }
 }


### PR DESCRIPTION
1. Fix error when aggregating jobs with null fields
2. Add unit tests to check if the behaviour is the one desired